### PR TITLE
Adds pyside2 formulas

### DIFF
--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -29,8 +29,8 @@ class Freecad < Formula
     depends_on "cartr/qt4/qt@4"
     depends_on "cartr/qt4/pyside-tools@1.2"
   else
-    depends_on "qt@5.6"
-    depends_on "FreeCAD/freecad/pyside-tools"
+    depends_on "qt"
+    depends_on "FreeCAD/freecad/pyside2-tools"
   end
   depends_on "opencascade"
   depends_on "orocos-kdl"

--- a/Formula/pyside2-tools.rb
+++ b/Formula/pyside2-tools.rb
@@ -1,0 +1,20 @@
+class Pyside2Tools < Formula
+  desc "PySide development tools (pyuic and pyrcc)"
+  homepage "https://wiki.qt.io/PySide2"
+  url "https://codereview.qt-project.org/gitweb?p=pyside/pyside-tools.git;a=snapshot;h=5d6b74066e61069358a3331114ab21252d079e69;sf=tgz"
+  sha256 "23ce27ce8fa9fd305592d2ee69737d96249467faab7b1c5b47e4cd2677353761"
+  version "5.9-1"
+  # Git commit log 'https://codereview.qt-project.org/gitweb?p=pyside/pyside-tools.git'
+
+  head "https://codereview.qt-project.org/pyside/pyside-tools", :branch => "5.9"
+
+  depends_on "cmake" => :build
+  depends_on "FreeCAD/freecad/pyside2"
+
+  def install
+    mkdir "macbuild" do
+      system "cmake", "..", "-DSITE_PACKAGE=lib/python2.7/site-packages", *std_cmake_args
+      system "make", "install"
+    end
+  end
+end

--- a/Formula/pyside2.rb
+++ b/Formula/pyside2.rb
@@ -1,34 +1,76 @@
 class Pyside2 < Formula
-  desc "Python bindings for Qt"
+  desc "Python bindings for Qt5 and greater"
   homepage "https://wiki.qt.io/PySide2"
-  # TODO: Need to change this so it also gets the submodules, or wait until it's fixed upstream
-  url "https://codereview.qt-project.org/gitweb?p=pyside/pyside-setup.git;a=snapshot;h=04af851b4b886675fc68e0f8e637d9e399d4000c;sf=tgz"
-  sha256 "46c750e4f67f87b78627f45c4a4f74bd3a418681f6dc66468b140c23b1265965"
-  version "2.0.0-04af851"
-  head "https://code.qt.io/pyside/pyside-setup.git", :branch => "dev"
+  url "https://codereview.qt-project.org/gitweb?p=pyside/pyside-setup.git;a=snapshot;h=5c5ad6eb7a48b940841e6a15e3a802936b1adcae;sf=tgz"
+  sha256 "2ae1a65cae10e197975d11d7f8c72c524cad973403c83f3d470d0e993c56f8d6"
+  version "5.9-1"
+  # Git commits
+  # 'https://codereview.qt-project.org/gitweb?p=pyside/pyside-setup.git;a=shortlog;h=refs/heads/5.9'
 
+  head "https://codereview.qt-project.org/pyside/pyside-setup", :branch => "5.9"
+
+  # don't use depends_on :python because then bottles install Homebrew's python
   option "without-python", "Build without python 2 support"
   depends_on "python" => :recommended
   depends_on "python3" => :optional
 
+  option "without-docs", "Skip building documentation"
+
   depends_on "cmake" => :build
-  depends_on "llvm" => :build
+  depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "qt"
 
+  if build.with? "python3"
+    depends_on "FreeCAD/freecad/shiboken2" => "with-python3"
+  else
+    depends_on "FreeCAD/freecad/shiboken2"
+  end
+
   def install
-    ENV["LLVM_INSTALL_DIR"] = Formula["llvm"].opt_prefix
+    ENV.cxx11
 
     # This is a workaround for current problems with Shiboken2
     ENV["HOMEBREW_INCLUDE_PATHS"] = ENV["HOMEBREW_INCLUDE_PATHS"].sub(Formula["qt"].include, "")
 
+    rm buildpath/"sources/pyside2/doc/CMakeLists.txt" if build.without? "docs"
+    qt = Formula["qt"]
+
+    # Add out of tree build because one of its deps, shiboken, itself needs an
+    # out of tree build in shiboken.rb.
     Language::Python.each_python(build) do |python, version|
-      system python, *Language::Python.setup_install_args(prefix)
+      pyhome = `python#{version}-config --prefix`.chomp
+      ENV["PYTHONHOME"] = pyhome
+      py_library = "#{pyhome}/lib/libpython2.7.dylib"
+      py_include = "#{pyhome}/include/python2.7"
+
+      mkdir "macbuild#{version}" do
+
+        args = std_cmake_args + %W[
+          -DPYTHON_EXECUTABLE=#{pyhome}/bin/python#{version}
+          -DPYTHON_LIBRARY=#{py_library}
+          -DPYTHON_INCLUDE_DIR=#{py_include}
+          -DSITE_PACKAGE=#{lib}/python#{version}/site-packages
+          -DQT_SRC_DIR=#{qt.include}
+          -DALTERNATIVE_QT_INCLUDE_DIR=#{qt.opt_prefix}/include
+          -DCMAKE_PREFIX_PATH=#{qt.prefix}/lib/cmake/
+          -DBUILD_TESTS:BOOL=OFF
+        ]
+        args << "../sources/pyside2"
+        system "cmake", *args
+        system "make"
+        system "make", "install"
+      end
+
+      # Work-around to https://bugreports.qt.io/browse/PYSIDE-494
+      #rm prefix/"lib/python2.7/site-packages/PySide2/QtTest.so"
     end
+
+    #inreplace include/"PySide2/pyside2_global.h", qt.prefix, qt.opt_prefix
   end
 
   test do
     Language::Python.each_python(build) do |python, _version|
-      system python, "-c", "from PySide import QtCore"
+      system python, "-c", "from PySide2 import QtCore"
     end
   end
 end

--- a/Formula/shiboken2.rb
+++ b/Formula/shiboken2.rb
@@ -1,0 +1,58 @@
+class Shiboken2 < Formula
+  desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
+  homepage "https://wiki.qt.io/PySide2"
+  url "https://codereview.qt-project.org/gitweb?p=pyside/pyside-setup.git;a=snapshot;h=5c5ad6eb7a48b940841e6a15e3a802936b1adcae;sf=tgz"
+  sha256 "07c16f64a6e52e11c9643ef11e798a256a857ec4b791ee518704601f594ca4f3"
+  version "5.9-1"
+  # Git commits 'https://codereview.qt-project.org/gitweb?p=pyside/shiboken.git'
+
+  head "https://codereview.qt-project.org/#/admin/projects/pyside/pyside-setup", :branch => "5.9"
+
+  depends_on "cmake" => :build
+  depends_on "llvm"
+  depends_on "qt"
+
+  # don't use depends_on :python because then bottles install Homebrew's python
+  option "without-python", "Build without python 2 support"
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
+
+  def install
+    # ENV.deparallelize  # if your formula fails when building in parallel
+    qt = Formula["qt"]
+    llvm = Formula["llvm"]
+    ENV['LLVM_INSTALL_DIR']="#{llvm.prefix}"
+    # As of 1.1.1 the install fails unless you do an out of tree build and put
+    # the source dir last in the args.
+    Language::Python.each_python(build) do |python, version|
+      mkdir "macbuild#{version}" do
+        args = std_cmake_args
+        # Building the tests also runs them.
+        args << "-DBUILD_TESTS=ON"
+        if python == "python3" && Formula["python3"].installed?
+          python_framework = Formula["python3"].opt_prefix/"Frameworks/Python.framework/Versions/#{version}"
+          args << "-DPYTHON3_INCLUDE_DIR:PATH=#{python_framework}/Headers"
+          args << "-DPYTHON3_LIBRARY:FILEPATH=#{python_framework}/lib/libpython#{version}.dylib"
+        end
+        args << "-DUSE_PYTHON3:BOOL=ON" if python == "python3"
+        args << "-DCMAKE_PREFIX_PATH=#{qt.prefix}/lib/cmake/"
+        args << "../sources/shiboken2"
+        system "cmake", *args
+        system "make", "install"
+      end
+    end
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! It's enough to just replace
+    # "false" with the main program this formula installs, but it'd be nice if you
+    # were more thorough. Run the test with `brew test shiboken2`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end


### PR DESCRIPTION
Adds support for pyside2, pyside2-tools, and shiboken2.
Bypasses the setup.py based build as it's problematic, and simply relies on the
(working) cmake based build.

fixes #58 