### PR TITLE
fix: do not pin head to specific commit but rather point to HEAD

### DIFF
--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -1,6 +1,7 @@
 class Freecad < Formula
   desc "Parametric 3D modeler"
   homepage "http://www.freecadweb.org"
+  license "GPL-2.0-only"
   url "https://github.com/freecad/FreeCAD.git", :using => :git, :commit => "34a083b15997a2694bb29328c440225cad976bd9"
   version "0.19pre"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -2,9 +2,15 @@ class Freecad < Formula
   desc "Parametric 3D modeler"
   homepage "http://www.freecadweb.org"
   license "GPL-2.0-only"
-  url "https://github.com/freecad/FreeCAD.git", :using => :git, :commit => "34a083b15997a2694bb29328c440225cad976bd9"
   version "0.19pre"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
+
+  stable do
+    # a tested commit that builds on macos high sierra 10.13 & mojave 10.14
+    url "https://github.com/freecad/freecad.git",
+      revision: "f35d30bc58cc2000754d4f30cf29d063416cfb9e"
+    version "0.19pre-dev"
+  end
 
   # Debugging Support
   option "with-debug", "Enable debug build"

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -6,7 +6,7 @@ class Freecad < Formula
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 
   stable do
-    # a tested commit that builds on macos high sierra 10.13 & mojave 10.14
+    # a tested commit that builds on macos high sierra 10.13, mojave 10.14, Catalina 10.15 & BigSur 11.0
     url "https://github.com/freecad/freecad.git",
       revision: "f35d30bc58cc2000754d4f30cf29d063416cfb9e"
     version "0.19pre-dev"

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -3,7 +3,7 @@ class Freecad < Formula
   homepage "http://www.freecadweb.org"
   url "https://github.com/freecad/FreeCAD.git", :using => :git, :commit => "34a083b15997a2694bb29328c440225cad976bd9"
   version "0.19pre"
-  head "https://github.com/freecad/FreeCAD.git", :commit => "34a083b15997a2694bb29328c440225cad976bd9"
+  head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 
   # Debugging Support
   option "with-debug", "Enable debug build"


### PR DESCRIPTION
this PR fixes the freecad formula when building with `--HEAD` flag or `-s`, `--build-from-source` when running `brew install`.

---

for whatever it's worth, running `brew audit freecad` on this formula reports 76 problems. as this formula currently sits. 🤷‍♂️ i'll submit a few more discrete PR's to this formula as opposed to one monolithic PR.