### PR TITLE
Fix FreeCAD --head build 

### DIFF
--- a/Formula/boost-python3@1.75.0.rb
+++ b/Formula/boost-python3@1.75.0.rb
@@ -20,7 +20,7 @@ class BoostPython3AT1750 < Formula
   keg_only "provided by homebrew core"
 
   bottle do
-    root_url "https://justyour.parts/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "3dd7c81b4cf643895a8c3c7a514a3edd9249387e9251bad646eb51ff77873f1c" => :big_sur
     sha256 "3b1bf01ad68f74b340a4a384347f25b7e6ca0d0180ded19fe28cbaa5330b77cd" => :catalina

--- a/Formula/boost-python3@1.75.0.rb
+++ b/Formula/boost-python3@1.75.0.rb
@@ -12,15 +12,15 @@ class BoostPython3AT1750 < Formula
   depends_on "#@tap/python3.9"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
-    sha256 "25a559efebce0f9e4d4a8682853e64aaf94ace29004028fe7768275fea827c36" => :big_sur
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" => :big_sur
   end
 
   keg_only "provided by homebrew core"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts/freecad"
     cellar :any
     sha256 "3dd7c81b4cf643895a8c3c7a514a3edd9249387e9251bad646eb51ff77873f1c" => :big_sur
     sha256 "3b1bf01ad68f74b340a4a384347f25b7e6ca0d0180ded19fe28cbaa5330b77cd" => :catalina

--- a/Formula/boost@1.75.0.rb
+++ b/Formula/boost@1.75.0.rb
@@ -26,7 +26,7 @@ class BoostAT1750 < Formula
   end
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "99aa624e3a19ba01458f9e0be8dcdcfb8df90feabc4728b188682d9174b05f09" => :big_sur
     sha256 "21fc3612d49249ff563dacedb633dbf8050a8e1ab3feb0100395a500fa610624" => :catalina

--- a/Formula/coin@4.0.0.rb
+++ b/Formula/coin@4.0.0.rb
@@ -15,7 +15,7 @@ class CoinAT400 < Formula
   keg_only "Provided by homebrew"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "7ffc242e36407db7cd5195cd62e9b6998b6114e9a7fdf70adadecfef0507e316" => :big_sur
     sha256 "841ef05f4072eedc91a16845e3a8ed2e4c941faef5b338b7fd424649806de983" => :catalina

--- a/Formula/cython@0.29.21.rb
+++ b/Formula/cython@0.29.21.rb
@@ -17,7 +17,7 @@ class CythonAT02921 < Formula
 
   depends_on "#@tap/python3.9"
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any_skip_relocation
     sha256 "d3d1198be33a79623df1da0236ce0ab35d194f817745819248a5d65e82f5067f" => :big_sur
     sha256 "780c1424d627c4f8a642f4c9323e09859e2fcece5c0f2c3b8868e77a907c692a" => :catalina

--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -1,0 +1,54 @@
+class Elmer < Formula
+  desc "Elmer CFD"
+  homepage "https://www.csc.fi/web/elmer"
+  version "v10pre"
+  license "GPL-2.0-only"
+  head "https://github.com/ElmerCSC/elmerfem.git", branch: "devel", shallow: false
+
+  stable do
+    url "https://github.com/ElmerCSC/elmerfem.git",
+      revision: "c40a03f2d0c77fa66afa7a476e8981fa8b7d74ac"
+    version "v10pre"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "#@tap/qwtelmer"
+  depends_on macos: :high_sierra # no access to sierra test box
+  depends_on "open-mpi"
+  depends_on "openblas"
+  depends_on "#@tap/opencascade@7.5.0"
+  depends_on "#@tap/python3.9"
+  depends_on "#@tap/qt5152"
+  depends_on "#@tap/vtk@8.2.0"
+  depends_on "webp"
+  depends_on "xerces-c"
+  depends_on "gcc"
+
+
+  def install
+
+    args = std_cmake_args + %W[
+	-DWITH_OpenMP:BOOLEAN=TRUE
+	-DWITH_MPI:BOOLEAN=TRUE
+	-DWITH_ELMERGUI:BOOLEAN=TRUE
+	-DWITH_QT5:BOOLEAN=TRUE
+    ]
+
+    args << '-DQWT_INCLUDE_DIR:STRING='+Formula["#@tap/qwtelmer"].opt_prefix+'/lib/qwt.framework/Versions/Current/Headers/' 
+    args << '-DQWT_LIBRARY:STRING='+Formula["#@tap/qwtelmer"].opt_prefix+'/lib/qwt.framework/Versions/Current/qwt'
+    args << '-DCMAKE_PREFIX_PATH="' + Formula["#@tap/qt5152"].opt_prefix + "/lib/cmake;" + Formula["#@tap/vtk@8.2.0"].opt_prefix + "/lib/cmake;" + Formula["#@tap/opencascade@7.5.0"].opt_prefix + "/lib/cmake;"+ '" -DCMAKE_C_FLAGS="-F' + Formula["#@tap/qwtelmer"].opt_prefix+"/lib/" + ' -framework qwt"'
+
+    mkdir "Build" do
+      system "cmake", *args, ".."
+      system "make", "-j#{ENV.make_jobs}", "install"
+    end
+  end
+
+  def post_install
+  end
+
+  def caveats
+    <<-EOS
+    EOS
+  end
+end

--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -12,14 +12,14 @@ class Elmer < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "#@tap/qwtelmer"
+  depends_on "freecad/freecad/qwtelmer"
   depends_on macos: :high_sierra # no access to sierra test box
   depends_on "open-mpi"
   depends_on "openblas"
-  depends_on "#@tap/opencascade@7.5.0"
-  depends_on "#@tap/python3.9"
-  depends_on "#@tap/qt5152"
-  depends_on "#@tap/vtk@8.2.0"
+  depends_on "freecad/freecad/opencascade@7.5.0"
+  depends_on "freecad/freecad/python3.9"
+  depends_on "freecad/freecad/qt5152"
+  depends_on "freecad/freecad/vtk@8.2.0"
   depends_on "webp"
   depends_on "xerces-c"
   depends_on "gcc"
@@ -34,9 +34,9 @@ class Elmer < Formula
 	-DWITH_QT5:BOOLEAN=TRUE
     ]
 
-    args << '-DQWT_INCLUDE_DIR:STRING='+Formula["#@tap/qwtelmer"].opt_prefix+'/lib/qwt.framework/Versions/Current/Headers/' 
-    args << '-DQWT_LIBRARY:STRING='+Formula["#@tap/qwtelmer"].opt_prefix+'/lib/qwt.framework/Versions/Current/qwt'
-    args << '-DCMAKE_PREFIX_PATH="' + Formula["#@tap/qt5152"].opt_prefix + "/lib/cmake;" + Formula["#@tap/vtk@8.2.0"].opt_prefix + "/lib/cmake;" + Formula["#@tap/opencascade@7.5.0"].opt_prefix + "/lib/cmake;"+ '" -DCMAKE_C_FLAGS="-F' + Formula["#@tap/qwtelmer"].opt_prefix+"/lib/" + ' -framework qwt"'
+    args << '-DQWT_INCLUDE_DIR:STRING='+Formula["freecad/freecad/qwtelmer"].opt_prefix+'/lib/qwt.framework/Versions/Current/Headers/' 
+    args << '-DQWT_LIBRARY:STRING='+Formula["freecad/freecad/qwtelmer"].opt_prefix+'/lib/qwt.framework/Versions/Current/qwt'
+    args << '-DCMAKE_PREFIX_PATH="' + Formula["freecad/freecad/qt5152"].opt_prefix + "/lib/cmake;" + Formula["freecad/freecad/vtk@8.2.0"].opt_prefix + "/lib/cmake;" + Formula["freecad/freecad/opencascade@7.5.0"].opt_prefix + "/lib/cmake;"+ '" -DCMAKE_C_FLAGS="-F' + Formula["freecad/freecad/qwtelmer"].opt_prefix+"/lib/" + ' -framework qwt"'
 
     mkdir "Build" do
       system "cmake", *args, ".."

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -65,7 +65,8 @@ class Freecad < Formula
     args = std_cmake_args + %W[
       -DBUILD_QT5=ON
       -DUSE_PYTHON3=1
-      -DPYTHON_EXECUTABLE=/usr/local/opt/python3.9/bin/python3
+      -DPYTHON_EXECUTABLE=Formula["#@tap/python3.9"].opt_prefix + "/bin/python3"
+      -DPYTHON_INCLUDE_DIR=Formula["#@tap/python3.9"].opt_prefix + "/Frameworks/Python.framework/Headers"
       -DCMAKE_CXX_STANDARD=14
       -DBUILD_ENABLE_CXX_STD:STRING=C++14
       -DBUILD_FEM_NETGEN=1

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -1,15 +1,15 @@
 class Freecad < Formula
   desc "Parametric 3D modeler"
   homepage "http://www.freecadweb.org"
-  version "0.19pre"
+  version "0.19"
   license "GPL-2.0-only"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 
   stable do
     # a tested commit that builds on macos high sierra 10.13, mojave 10.14, Catalina 10.15 & BigSur 11.0
     url "https://github.com/freecad/freecad.git",
-      revision: "f35d30bc58cc2000754d4f30cf29d063416cfb9e"
-    version "0.19pre-dev"
+      revision: "a88db11e0a908f6e38f92bfc5187b13ebe470438"
+    version "0.19"
   end
 
   option "with-debug", "Enable debug build"
@@ -20,7 +20,7 @@ class Freecad < Formula
 
   depends_on "ccache" => :build
   depends_on "cmake" => :build
-  depends_on "swig" => :build
+  depends_on "#@tap/swig@4.0.2" => :build
   depends_on "#@tap/boost@1.75.0"
   depends_on "#@tap/boost-python3@1.75.0"
   depends_on "#@tap/coin@4.0.0"
@@ -46,8 +46,8 @@ class Freecad < Formula
   depends_on "xerces-c"
 
   bottle do
-    root_url "https:/dl.bintray.com/vejmarie/freecad"
-    sha256 "f9bc13c49a0ab3d72437dd721aa362d77638b68ad05f2bdcaeadf91b6d5e537b" => :big_sur
+    root_url "https://justyour.parts:8080/freecad"
+    sha256 "ea3f380ce4998d4fcb82d2dd7139957c4865b35dfbbab18d8d0479676e91aa14" => :big_sur
     sha256 "8ef75eb7cea8ca34dc4037207fb213332b9ed27976106fd83c31de1433c2dd29" => :catalina
   end
 
@@ -66,7 +66,6 @@ class Freecad < Formula
       -DBUILD_QT5=ON
       -DUSE_PYTHON3=1
       -DPYTHON_EXECUTABLE=/usr/local/opt/python3.9/bin/python3
-      -std=c++14
       -DCMAKE_CXX_STANDARD=14
       -DBUILD_ENABLE_CXX_STD:STRING=C++14
       -DBUILD_FEM_NETGEN=1

--- a/Formula/icu4c@67.1.rb
+++ b/Formula/icu4c@67.1.rb
@@ -22,7 +22,7 @@ class Icu4cAT671 < Formula
   end
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "550f2586ae316232721903c627a53932a9a2f2032cade00ed31ec5dab3e2727e" => :big_sur
     sha256 "02832f36ac5c5e7e3003c40b7b0abdc76026010f9be5b9a50d3c092d27aacc14" => :catalina

--- a/Formula/matplotlib.rb
+++ b/Formula/matplotlib.rb
@@ -103,7 +103,7 @@ class Matplotlib < Formula
   end
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "150759a0b8ea4e159e0a4ed1229340775e90ab6b47ab397fe1ec040250ceef94" => :big_sur
     sha256 "7f3d19de027ab6dd81e6b6021315682bcfe54f410bb29a1fb1cea0ba0a8515eb" => :catalina

--- a/Formula/med-file.rb
+++ b/Formula/med-file.rb
@@ -11,7 +11,7 @@ class MedFile < Formula
   depends_on "#@tap/python3.9"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "21dc7b948d4bf3e022690bd075ed9f6e623c7d08088178f60a4f9f9acc70367c" => :big_sur
     sha256 "d66199bb1cbd71baf8f17bbef258fe64f02fe6f7cfc21427555f3c5b31297e1d" => :catalina

--- a/Formula/nglib.rb
+++ b/Formula/nglib.rb
@@ -8,7 +8,7 @@ class Nglib < Formula
   depends_on "cmake" => :build
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "317c6c9432a0431a0dd5abb7c942d138160b6b84217aedf532c2d4a7fc7fe6ae" => :big_sur
     sha256 "9a86c95e0358b98b9d8dcd614167d8e1812407ac1d070c83f52249bce71da960" => :catalina

--- a/Formula/numpy@1.19.4.rb
+++ b/Formula/numpy@1.19.4.rb
@@ -11,7 +11,7 @@ class NumpyAT1194 < Formula
   end
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "525f5e733bf4677cb94d91549c88addfa59559cf9ccd6decb163ab906763cacf" => :big_sur
     sha256 "b634193a2e1c28438bc659622ef90c151bb8f5bbf2d5ae03f877df43c4f9d9a1" => :catalina

--- a/Formula/opencamlib.rb
+++ b/Formula/opencamlib.rb
@@ -16,7 +16,7 @@ class Opencamlib < Formula
   depends_on "#@tap/boost-python3@1.75.0" => :build
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "8e81823c6b42837caf46f39f7ffae2d217e8080bd5cc21ff9092918e173e8c59" => :big_sur
     sha256 "695a0c707cc565aaa181049a2958e80fcaf21a76c573983e9d1314a19e90c8bd" => :catalina

--- a/Formula/opencascade@7.5.0.rb
+++ b/Formula/opencascade@7.5.0.rb
@@ -18,7 +18,7 @@ class OpencascadeAT750 < Formula
   depends_on "#@tap/tbb@2020_u3"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "1f625aeaef44b9a78714fae89f5feaa79ce43ae1515b3cb6139cfce3d603e412" => :big_sur
     sha256 "721771a181d3d8b3c2863df9ebf91d6f50e858ef81ed9cf2440c60bc6569fcc8" => :catalina

--- a/Formula/pivy.rb
+++ b/Formula/pivy.rb
@@ -10,7 +10,7 @@ class Pivy < Formula
   depends_on "#@tap/coin@4.0.0"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "4d40838f8825a183c30ae69f2aee8dc345377190d7e35d13e00a9b1bb6cae2a0" => :big_sur
     sha256 "90cb40af64f8827838af9312fd5481c6d52a88bf61c04bdf2b7f6593baad6609" => :catalina

--- a/Formula/pyqt@5.15.2.rb
+++ b/Formula/pyqt@5.15.2.rb
@@ -22,7 +22,7 @@ class PyqtAT5152 < Formula
   keg_only "Also provided by core..."
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "7bb680628800decb3c84adc40081fa44f8151c5241ede9c5534af16fe41612e0" => :big_sur
     sha256 "25424bdc32b5a43929e637f2e6c0f1bc3b20bf03c13756ea7ba80bec819a9d43" => :catalina

--- a/Formula/pyside2-tools.rb
+++ b/Formula/pyside2-tools.rb
@@ -10,7 +10,7 @@ class Pyside2Tools < Formula
   depends_on "#@tap/pyside2"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "d3ab67c4bd9e47f8505b36445c496fca3109aab1a4ad59a0c370734c9001c3c3" => :big_sur
     sha256 "313cdb6754ad9f62abd03e8bfcc9f270bc308a5405fe91a56659d26d420db287" => :catalina

--- a/Formula/pyside2.rb
+++ b/Formula/pyside2.rb
@@ -16,7 +16,7 @@ class Pyside2 < Formula
   depends_on "#@tap/shiboken2" 
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "87097214bd3ba561836bf7a0aa83c2433491b211ed1e550efb7630bf4f7dc87d" => :big_sur
     sha256 "17c919f37f96e588cd5256c3ee9cd1e0e0b9e1ea528d40cf74e2a3acb3ef1b67" => :catalina

--- a/Formula/python3.9.rb
+++ b/Formula/python3.9.rb
@@ -90,7 +90,7 @@ class Python39 < Formula
   keg_only "FreeCAD python version only"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     sha256 "847f0924e04052940cb66733267e31d3338131822863d1ff73d4cc5d5c90005b" => :big_sur
     sha256 "5448b5eb25fde4859c568821e59bfb5d488eb1f00bce5ecd97a545585f411aca" => :catalina
   end

--- a/Formula/qt5152.rb
+++ b/Formula/qt5152.rb
@@ -35,7 +35,7 @@ class Qt5152 < Formula
   end
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "9b3268db7be55f3c215d4a3221f28bae3dbaf8ed506222cc1b4a78b7e44a5936" => :big_sur
     sha256 "e71e5f33519372f3f9776fc159b9bce93891a1b3c2a6778aa0b1663abcb2f8c3" => :catalina

--- a/Formula/qwtelmer.rb
+++ b/Formula/qwtelmer.rb
@@ -1,0 +1,79 @@
+class Qwtelmer < Formula
+  desc "Qt Widgets for Technical Applications"
+  homepage "https://qwt.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.6/qwt-6.1.6.tar.bz2"
+  sha256 "99460d31c115ee4117b0175d885f47c2c590d784206f09815dc058fbe5ede1f6"
+  license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
+  revision 1
+
+  depends_on "#@tap/qt5152"
+
+  # Update designer plugin linking back to qwt framework/lib after install
+  # See: https://sourceforge.net/p/qwt/patches/45/
+  patch :DATA
+
+  def install
+    inreplace "qwtconfig.pri" do |s|
+      s.gsub!(/^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}")
+
+      # Install Qt plugin in `lib/qt/plugins/designer`, not `plugins/designer`.
+      s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
+             "\\1/lib/qt/\\2"
+    end
+
+    args = ["-config", "release", "-spec"]
+    spec = if ENV.compiler == :clang
+      "macx-clang"
+    else
+      "macx-g++"
+    end
+    spec << "-arm64" if Hardware::CPU.arm?
+    args << spec
+
+    qt5 = Formula["#@tap/qt5152"].opt_prefix
+    system "#{qt5}/bin/qmake", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <qwt_plot_curve.h>
+      int main() {
+        QwtPlotCurve *curve1 = new QwtPlotCurve("Curve 1");
+        return (curve1 == NULL);
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "out",
+      "-std=c++11",
+      "-framework", "qwt", "-framework", "QtCore",
+      "-F#{lib}", "-F#{Formula["#@tap/qt5152"].opt_lib}",
+      "-I#{lib}/qwt.framework/Headers",
+      "-I#{Formula["#@tap/qt5152"].opt_lib}/QtCore.framework/Versions/5/Headers",
+      "-I#{Formula["#@tap/qt5152"].opt_lib}/QtGui.framework/Versions/5/Headers"
+    system "./out"
+  end
+end
+
+__END__
+diff --git a/designer/designer.pro b/designer/designer.pro
+index c269e9d..c2e07ae 100644
+--- a/designer/designer.pro
++++ b/designer/designer.pro
+@@ -126,6 +126,16 @@ contains(QWT_CONFIG, QwtDesigner) {
+
+     target.pelmerath = $${QWT_INSTALL_PLUGINS}
+     INSTALLS += target
++
++    macx {
++        contains(QWT_CONFIG, QwtFramework) {
++            QWT_LIB = qwt.framework/Versions/$${QWT_VER_MAJ}/qwt
++        }
++        else {
++            QWT_LIB = libqwt.$${QWT_VER_MAJ}.dylib
++        }
++        QMAKE_POST_LINK = install_name_tool -change $${QWT_LIB} $${QWT_INSTALL_LIBS}/$${QWT_LIB} $(DESTDIR)$(TARGET)
++    }
+ }
+ else {
+     TEMPLATE        = subdirs # do nothing

--- a/Formula/shiboken2.rb
+++ b/Formula/shiboken2.rb
@@ -12,7 +12,7 @@ class Shiboken2 < Formula
   depends_on "#@tap/python3.9" => :build
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "9fcaf2c809c9d335bf6e7f3009ddfec63040051c8d9dff7f47d5430579319e5d" => :big_sur
     sha256 "94c2375a547b26b06128cd8705de6bd3f42f8a445dea5a2d9202040f9e61a033" => :catalina

--- a/Formula/sip@4.19.24.rb
+++ b/Formula/sip@4.19.24.rb
@@ -16,7 +16,7 @@ class SipAT41924 < Formula
   depends_on "#@tap/python3.9"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any_skip_relocation
     sha256 "a3e1a54c30560552e7c4dc4bd0da95925be88c7eef2a9349b72e11b24f827616" => :big_sur
     sha256 "c3b3dafcf16f0e65bea4ba6daf62d8e15394ee7201073008a7c7aa22c9864e81" => :catalina

--- a/Formula/swig@4.0.2.rb
+++ b/Formula/swig@4.0.2.rb
@@ -21,7 +21,7 @@ class SwigAT402 < Formula
   uses_from_macos "ruby" => :test
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     sha256 "ed574acdb012636fb46ddbf0e4e362f26165aa530d34d26968dece33deb50f14" => :big_sur
     sha256 "bc218307d7a855276c2d97ceb81c4cac4d48c60f3be41e231bd62cde3629ba61" => :catalina
   end

--- a/Formula/tbb@2020_u3.rb
+++ b/Formula/tbb@2020_u3.rb
@@ -12,7 +12,7 @@ class TbbAT2020U3 < Formula
   depends_on "#@tap/python3.9"
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     cellar :any
     sha256 "62f987215e72d992507d6b9e0f1fcef19afac7e939b508db35f76112bda94ab7" => :big_sur
     sha256 "0a2ea081cf8647fd270229d9da1b01909d77b4052e1b516b01e2998176567d9a" => :catalina

--- a/Formula/vtk@8.2.0.rb
+++ b/Formula/vtk@8.2.0.rb
@@ -41,7 +41,7 @@ class VtkAT820 < Formula
   end
 
   bottle do
-    root_url "https://dl.bintray.com/vejmarie/freecad"
+    root_url "https://justyour.parts:8080/freecad"
     sha256 "cc762d3f3a9a2c851ef3ca3447129ab93ddd9eb788024c962200e4158b04fef0" => :big_sur
     sha256 "da4cf1a9a932149b920c60290b4dc139a62f73abce12389fb25053a5fff42a4a" => :catalina
   end


### PR DESCRIPTION
Add also Elmer as a Formula into FreeCAD repo. Elmer can be used as a CFD for the FeM module and doesn't have an integrated fomrula. It is dependant from OpenCascade and Qt, might make sense to extend our formula support to it.

Use justyour.parts server as a primary source for bottles. Bottles can be retrieve from it more easily than from bintray and this will be a temporary solution up to the time we find alternative.