### PR TITLE
Fix macapp build with homebrew (needs a FreeCAD fix)

### DIFF
--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -38,6 +38,7 @@ class Freecad < Formula
   depends_on "#{@tap}/pyside2"
   depends_on "#{@tap}/pyside2-tools"
   depends_on "#{@tap}/shiboken2"
+  depends_on "#{@tap}/icu4c@67.1"
   depends_on "freetype"
   depends_on macos: :high_sierra # no access to sierra test box
   depends_on "open-mpi"
@@ -59,7 +60,7 @@ class Freecad < Formula
       ENV["CC"] = Formula["llvm"].opt_bin/"clang"
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
     end
-
+    ENV["PKG_CONFIG_PATH"] = Formula["icu4c@67.1"].opt_prefix + "/lib/pkgconfig"
     args = std_cmake_args + %W[
       -DBUILD_QT5=ON
       -DUSE_PYTHON3=1


### PR DESCRIPTION
This is fixing the creation of the MacApp when using homebrew. Needs currently some fixes into freecad tree into src/MacAppBundle/CMakeLists.txt which is lacking a few includes to build the bundle.

For pure testing you can use https://github.com/vejmarie/FreeCAD -> branch macbundle

It will successfully create the FreeCAD.app which can be copied into /Applications (it is rellocatable) and then successfully used.

Let me know your thoughts !

Signed-off-by: vejmarie <jmverdun3@gmail.com>