### PR TITLE
set the stable version of freecad to the v0.19.1 source tar ball

### DIFF
--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -1,7 +1,7 @@
 class Freecad < Formula
   desc "Parametric 3D modeler"
   homepage "http://www.freecadweb.org"
-  version "0.19.1"
+  version "0.19"
   license "GPL-2.0-only"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -1,15 +1,13 @@
 class Freecad < Formula
   desc "Parametric 3D modeler"
   homepage "http://www.freecadweb.org"
-  version "0.19"
+  version "0.19.1"
   license "GPL-2.0-only"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 
   stable do
-    # a tested commit that builds on macos high sierra 10.13, mojave 10.14, Catalina 10.15 & BigSur 11.0
-    url "https://github.com/freecad/freecad.git",
-      revision: "a88db11e0a908f6e38f92bfc5187b13ebe470438"
-    version "0.19"
+    url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.19.1.tar.gz"
+    sha256 "5ec0003c18df204f7b449d4ac0a82f945b41613a0264127de3ef16f6b2efa60f"
   end
 
   bottle do


### PR DESCRIPTION
updated the freecad formula file to use the stable release _0.19.1_ when downloading and build from source. which if different from building HEAD.