### PR TITLE
fix style errors for formula using `brew audit` in prep for setting up homebrew tap with github actions and workflows

### DIFF
--- a/Formula/boost-python3@1.75.0.rb
+++ b/Formula/boost-python3@1.75.0.rb
@@ -2,7 +2,6 @@ class BoostPython3AT1750 < Formula
   desc "C++ library for C++/Python3 interoperability"
   homepage "https://www.boost.org/"
   url "https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2"
-  mirror "https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2"
   sha256 "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
   license "BSL-1.0"
   head "https://github.com/boostorg/boost.git"
@@ -14,8 +13,8 @@ class BoostPython3AT1750 < Formula
 
   bottle do
     root_url "https://justyour.parts:8080/freecad"
-    sha256 big_sur: "3dd7c81b4cf643895a8c3c7a514a3edd9249387e9251bad646eb51ff77873f1c" 
-    sha256 catalina: "3b1bf01ad68f74b340a4a384347f25b7e6ca0d0180ded19fe28cbaa5330b77cd" 
+    sha256 big_sur: "3dd7c81b4cf643895a8c3c7a514a3edd9249387e9251bad646eb51ff77873f1c"
+    sha256 catalina: "3b1bf01ad68f74b340a4a384347f25b7e6ca0d0180ded19fe28cbaa5330b77cd"
   end
 
   keg_only "provided by homebrew core"
@@ -73,7 +72,8 @@ class BoostPython3AT1750 < Formula
 "include("+Formula["#{@tap}/boost@1.75.0"].opt_prefix+"/lib/cmake/BoostDetectToolset-1.75.0.cmake)"
     inreplace "install-python3/lib/cmake/boost_python-1.75.0/boost_python-config.cmake",
 "get_filename_component(_BOOST_INCLUDEDIR \"${_BOOST_CMAKEDIR}/../../include/\" ABSOLUTE)",
-"# get_filename_component(_BOOST_INCLUDEDIR \"${_BOOST_CMAKEDIR}/../../include/\" ABSOLUTE) \nset(_BOOST_LIBDIR \"/usr/local/opt/boost-python3@1.75.0/lib\")"
+"# get_filename_component(_BOOST_INCLUDEDIR \"${_BOOST_CMAKEDIR}/../../include/\" ABSOLUTE) \n
+set(_BOOST_LIBDIR \"/usr/local/opt/boost-python3@1.75.0/lib\")"
     inreplace "install-python3/lib/cmake/boost_python-1.75.0/boost_python-config.cmake",
 "get_filename_component(_BOOST_LIBDIR", "# get_filename_component(_BOOST_LIBDIR"
 

--- a/Formula/coin@4.0.0.rb
+++ b/Formula/coin@4.0.0.rb
@@ -1,9 +1,13 @@
 class CoinAT400 < Formula
   desc "Retained-mode toolkit for 3D graphics development"
   homepage "https://coin3d.github.io"
-  url "https://github.com/coin3d/coin", using: :git, tag: "Coin-4.0.0"
-  version "4.0.0"
-  head "https://github.com/coin3d/coin", using: :git
+  license all_of: ["BSD-3-Clause", "ISC"]
+  revision 1
+
+  stable do
+    url "https://github.com/coin3d/coin/archive/Coin-4.0.0.tar.gz"
+    sha256 "b00d2a8e9d962397cf9bf0d9baa81bcecfbd16eef675a98c792f5cf49eb6e805"
+  end
 
   bottle do
     root_url "https://justyour.parts:8080/freecad"
@@ -27,8 +31,8 @@ class CoinAT400 < Formula
     cmake_args << "-DCOIN_USE_CPACK:BOOL=OFF"
 
     mkdir "build-lib" do
-      system "mkdir", "../cpack.d"
-      system "touch", "../cpack.d/CMakeLists.txt"
+      mkdir "../cpack.d"
+      touch "../cpack.d/CMakeLists.txt"
       system "cmake", "..", *cmake_args
       system "make", "install"
     end

--- a/Formula/matplotlib.rb
+++ b/Formula/matplotlib.rb
@@ -53,7 +53,7 @@ class Matplotlib < Formula
 
   depends_on NoExternalPyCXXPackage => :build
   depends_on "pkg-config" => :build
-  depends_on "#{@tap}/numpy@1.19.4" 
+  depends_on "#{@tap}/numpy@1.19.4"
   depends_on DvipngRequirement if build.with? "tex"
   depends_on "freetype"
   depends_on "libpng"
@@ -65,8 +65,7 @@ class Matplotlib < Formula
   depends_on "ghostscript" => :optional
   depends_on "gtk+3" => :optional
   depends_on "pygobject3" => requires_py3 if build.with? "gtk+3"
-  # depends_on "pygtk" => :optional # OBSOLETE
-  depends_on "pygobject" if build.with? "pygtk"
+  depends_on "pygobject" => :optional
   depends_on "tcl-tk" => :optional
 
   cxxstdlib_check :skip

--- a/Formula/nglib.rb
+++ b/Formula/nglib.rb
@@ -1,8 +1,11 @@
 class Nglib < Formula
   desc "C++ Library of NETGEN's tetrahedral mesh generator"
-  homepage "https://sourceforge.net/projects/netgen-mesher/"
-  url "https://github.com/NGSolve/netgen.git", using: :git, tag: "v6.2.2007"
-  version "v6.2.2007"
+  homepage "https://github.com/ngsolve/netgen"
+  url "https://github.com/ngsolve/netgen.git", 
+    tag: "v6.2.2007",
+    revision: "9d71c172f33b62c18afa32fd90b836a3a7a0fc26"
+  license "LGPL-2.1"
+  head "https://github.com/ngsolve/netgen.git"
 
   bottle do
     root_url "https://justyour.parts:8080/freecad"
@@ -12,7 +15,7 @@ class Nglib < Formula
 
   depends_on "cmake" => :build
 
-  depends_on "#{@tap}/opencascade@7.5.0" => :required
+  depends_on "#{@tap}/opencascade@7.5.0"
 
   def install
     inreplace "CMakeLists.txt", "find_package(OpenCasCade REQUIRED)",

--- a/Formula/pivy.rb
+++ b/Formula/pivy.rb
@@ -1,9 +1,11 @@
 class Pivy < Formula
-  desc "Formula for freecad"
-  homepage "https://bitbucket.org/Coin3D/pivy/overview"
-  url "https://github.com/coin3d/pivy", using: :git, tag: "0.6.5"
-  version "0.6.5"
-  head "https://bitbucket.org/Coin3D/pivy", using: :git
+  desc "python bindings to coin3d"
+  homepage "https://github.com/coin3d/pivy"
+  url "https://github.com/coin3d/pivy.git", 
+    tag: "0.6.5",
+    revision: "5cf70be7b1d0e9ed5ab8060b34cf51c94b77511e"
+  license "ISC"
+  head "https://github.com/coin3d/pivy.git"
 
   bottle do
     root_url "https://justyour.parts:8080/freecad"

--- a/Formula/pyside2-tools.rb
+++ b/Formula/pyside2-tools.rb
@@ -1,9 +1,11 @@
 class Pyside2Tools < Formula
   desc "PySide development tools (pyuic and pyrcc)"
   homepage "https://wiki.qt.io/PySide2"
-  url "http://code.qt.io/pyside/pyside-setup.git", using: :git, branch: "5.15.2"
-  version "5.15.2"
-  head "http://code.qt.io/pyside/pyside-setup.git", branch: "5.15.2"
+  url "http://code.qt.io/pyside/pyside-setup.git",
+    tag: "v5.15.2",
+    revision: "ef19637b7eab165accb8c3b0686061b21745ab74"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+  head "http://code.qt.io/cgit/pyside/pyside-setup.git", branch: "v5.15.2"
 
   bottle do
     root_url "https://justyour.parts:8080/freecad"

--- a/Formula/pyside2.rb
+++ b/Formula/pyside2.rb
@@ -1,9 +1,11 @@
 class Pyside2 < Formula
   desc "Python bindings for Qt5 and greater"
   homepage "https://wiki.qt.io/PySide2"
-  url "http://code.qt.io/pyside/pyside-setup.git", using: :git, branch: "5.15.2"
-  version "5.15.2"
-  head "http://code.qt.io/cgit/pyside/pyside-setup.git", branch: "5.15.2"
+  url "http://code.qt.io/cgit/pyside/pyside-setup.git",
+    tag: "v5.15.2",
+    revision: "ef19637b7eab165accb8c3b0686061b21745ab74"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+  head "http://code.qt.io/cgit/pyside/pyside-setup.git", branch: "v5.15.2"   
 
   bottle do
     root_url "https://justyour.parts:8080/freecad"

--- a/Formula/qt5152.rb
+++ b/Formula/qt5152.rb
@@ -6,7 +6,6 @@ class Qt5152 < Formula
   url "https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
   mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
   mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
-  version "5.15.2"
   sha256 "3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 

--- a/Formula/shiboken2.rb
+++ b/Formula/shiboken2.rb
@@ -1,7 +1,7 @@
 class Shiboken2 < Formula
   desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
   homepage "https://doc.qt.io/qtforpython/shiboken2/"
-  url "http://code.qt.io/pyside/pyside-setup.git", using: :git, branch: "5.15.2"
+  url "https://code.qt.io/cgit/pyside/pyside-setup.git/tag/?h=v5.15.2", using: :git, branch: "5.15.2"
   version "5.15.2"
   head "http://code.qt.io/pyside/pyside-setup.git", branch: "5.15.2"
 

--- a/Formula/sip@4.19.24.rb
+++ b/Formula/sip@4.19.24.rb
@@ -2,7 +2,6 @@ class SipAT41924 < Formula
   desc "Tool to create Python bindings for C and C++ libraries"
   homepage "https://www.riverbankcomputing.com/software/sip/intro"
   url "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.24/sip-4.19.24.tar.gz"
-  version "4.19.24"
   sha256 "edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
   revision 1

--- a/Formula/vtk@8.2.0.rb
+++ b/Formula/vtk@8.2.0.rb
@@ -30,19 +30,19 @@ class VtkAT820 < Formula
 
   # Fix compile issues on Mojave and later
   patch do
-    url "https://gitlab.kitware.com/vtk/vtk/commit/ca3b5a50d945b6e65f0e764b3138cad17bd7eb8d.patch"
+    url "https://gitlab.kitware.com/vtk/vtk/commit/ca3b5a50d945b6e65f0e764b3138cad17bd7eb8d.diff"
     sha256 "49574bb914e2564b21ab0fb23cadcccd7dd323ae7f0f26f64fd6346c3db14cd7"
   end
 
   # Python 3.8 compatibility
   patch do
-    url "https://gitlab.kitware.com/vtk/vtk/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab.patch"
+    url "https://gitlab.kitware.com/vtk/vtk/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab.diff"
     sha256 "41914057adc511527167b812f9604f1ff0aed74e12dc20c98bbc5c52ccab9cda"
   end
 
   # Qt 5.15 support
   patch do
-    url "https://gitlab.kitware.com/vtk/vtk/-/commit/797f28697d5ba50c1fa2bc5596af626a3c277826.patch"
+    url "https://gitlab.kitware.com/vtk/vtk/-/commit/797f28697d5ba50c1fa2bc5596af626a3c277826.diff"
     sha256 "01e870a943edea2a096c7bc9e43d2a70e10a5a80d1cd89b08868ab0f746c1c1c"
   end
 


### PR DESCRIPTION
this will be the first on several files changed in this tap in hopes of fixing the style errors for the formula contained within this repo.

i ran,

```
brew style $ghforks/homebrew-freecad/Formula/boost-python3@1.75.0.rb
```

there shouldn't be any issues with the style guide lines of the formula file now.

i also uninstalled and rebuilt the formula locally without any issues and the changes from this PR applied.

i selected the wrong branch from my development fork on the prior PR i sent. _my bad_