### PR TITLE
#nglib, update bottle definition for big sur

### DIFF
--- a/Formula/nglib.rb
+++ b/Formula/nglib.rb
@@ -9,7 +9,7 @@ class Nglib < Formula
 
   bottle do
     root_url "https://github.com/freecad/homebrew-freecad/releases/download/07.28.2021"
-    sha256 cellar: :any, big_sur:  "317c6c9432a0431a0dd5abb7c942d138160b6b84217aedf532c2d4a7fc7fe6ae"
+    sha256 cellar: :any, big_sur: "8f1e7974e4430e2c4bd2590c72ceecb1f02f186181fee836375d1492b64aa68e"
     sha256 cellar: :any, catalina: "9a86c95e0358b98b9d8dcd614167d8e1812407ac1d070c83f52249bce71da960"
     sha256 cellar: :any, mojave: "9397fe237ff560ab6b2d8bf9003d876637c2eeba645d620f0ce2a2d36474ea78"
   end

--- a/Formula/vtk@8.2.0.rb
+++ b/Formula/vtk@8.2.0.rb
@@ -32,19 +32,19 @@ class VtkAT820 < Formula
   # Fix compile issues on Mojave and later
   patch do
     url "https://gitlab.kitware.com/vtk/vtk/commit/ca3b5a50d945b6e65f0e764b3138cad17bd7eb8d.diff"
-    sha256 "49574bb914e2564b21ab0fb23cadcccd7dd323ae7f0f26f64fd6346c3db14cd7"
+    sha256 "b9f7a3ebf3c29f3cad4327eb15844ac0ee849755b148b60fef006314de8e822e"
   end
 
   # Python 3.8 compatibility
   patch do
     url "https://gitlab.kitware.com/vtk/vtk/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab.diff"
-    sha256 "41914057adc511527167b812f9604f1ff0aed74e12dc20c98bbc5c52ccab9cda"
+    sha256 "572c06a4ba279a133bfdcf0190fec2eff5f330fa85ad6a2a0b0f6dfdea01ca69"
   end
 
   # Qt 5.15 support
   patch do
-    url "https://gitlab.kitware.com/vtk/vtk/-/commit/797f28697d5ba50c1fa2bc5596af626a3c277826.diff"
-    sha256 "01e870a943edea2a096c7bc9e43d2a70e10a5a80d1cd89b08868ab0f746c1c1c"
+    url "https://gitlab.kitware.com/vtk/vtk/commit/797f28697d5ba50c1fa2bc5596af626a3c277826.diff"
+    sha256 "cb3b3a0e6978889a9cb95be35f3d4a6928397d3b843ab72ecaaf96554c6d4fc7"
   end
 
   def install


### PR DESCRIPTION
#189 

this pr should fix the sha256sum mismatches when building vtk@8.2.0 from source.