### PR TITLE
[no ci] add aliases for ngsolve → netgen

### DIFF
--- a/Aliases/netgen
+++ b/Aliases/netgen
@@ -1,0 +1,1 @@
+Formula/nglib.rb

--- a/Aliases/netgen@6.2.2104
+++ b/Aliases/netgen@6.2.2104
@@ -1,0 +1,1 @@
+Formula/nglib@6.2.2104.rb


### PR DESCRIPTION
add aliases for ngsolve to netgen

makes doing a

```
brew search netgen
```

a tad bit easier for finding netgen / ngsolve