### PR TITLE
fix "Another active Homebrew process ..."

### DIFF
--- a/Formula/coin@4.0.0.rb
+++ b/Formula/coin@4.0.0.rb
@@ -24,7 +24,7 @@ class CoinAT400 < Formula
 
   depends_on "cmake"   => :build
   depends_on "doxygen" => :build if build.with? "docs"
-  depends_on "./boost@1.75.0"
+  depends_on "freecad/freecad/boost@1.75.0"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -16,7 +16,7 @@ class Elmer < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "freecad/freecad/opencascade@7.5.0"
+  depends_on "freecad/freecad/opencascade@7.5.3"
   depends_on "freecad/freecad/python@3.9.6"
   depends_on "freecad/freecad/qt5152"
   depends_on "freecad/freecad/qwtelmer"

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -81,8 +81,8 @@ class Freecad < Formula
     args = std_cmake_args + %W[
       -DBUILD_QT5=ON
       -DUSE_PYTHON3=1
-      -DCMAKE_CXX_STANDARD=14
-      -DBUILD_ENABLE_CXX_STD:STRING=C++14
+      -DCMAKE_CXX_STANDARD=17
+      -DBUILD_ENABLE_CXX_STD:STRING=C++17
       -DBUILD_FEM_NETGEN=1
       -DBUILD_FEM=1
       -DBUILD_FEM_NETGEN:BOOL=ON

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -23,23 +23,23 @@ class Freecad < Formula
   option "with-unsecured-cloud", "Build with self signed certificate support CLOUD module"
   option "with-skip-web", "Disable web"
 
-  depends_on "./swig@4.0.2" => :build
   depends_on "ccache" => :build
   depends_on "cmake" => :build
-  depends_on "./boost-python3@1.75.0"
-  depends_on "./boost@1.75.0"
-  depends_on "./coin@4.0.0"
-  depends_on "./matplotlib"
-  depends_on "./med-file"
-  depends_on "./nglib"
-  depends_on "./opencamlib"
-  depends_on "./opencascade@7.5.0"
-  depends_on "./pivy"
-  depends_on "./pyside2"
-  depends_on "./pyside2-tools"
-  depends_on "./qt5152"
-  depends_on "./shiboken2"
-  depends_on "./vtk@8.2.0"
+  depends_on "freecad/freecad/swig@4.0.2" => :build
+  depends_on "freecad/freecad/boost-python3@1.75.0"
+  depends_on "freecad/freecad/boost@1.75.0"
+  depends_on "freecad/freecad/coin@4.0.0"
+  depends_on "freecad/freecad/matplotlib"
+  depends_on "freecad/freecad/med-file"
+  depends_on "freecad/freecad/nglib@6.2.2104"
+  depends_on "freecad/freecad/opencamlib"
+  depends_on "freecad/freecad/opencascade@7.5.3"
+  depends_on "freecad/freecad/pivy"
+  depends_on "freecad/freecad/pyside2"
+  depends_on "freecad/freecad/pyside2-tools"
+  depends_on "freecad/freecad/qt5152"
+  depends_on "freecad/freecad/shiboken2"
+  depends_on "freecad/freecad/vtk@8.2.0"
   depends_on "freecad/freecad/python@3.9.6"
   depends_on "freetype"
   depends_on macos: :high_sierra # no access to sierra test box

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -37,10 +37,10 @@ class Freecad < Formula
   depends_on "freecad/freecad/pivy"
   depends_on "freecad/freecad/pyside2"
   depends_on "freecad/freecad/pyside2-tools"
+  depends_on "freecad/freecad/python@3.9.6"
   depends_on "freecad/freecad/qt5152"
   depends_on "freecad/freecad/shiboken2"
   depends_on "freecad/freecad/vtk@8.2.0"
-  depends_on "freecad/freecad/python@3.9.6"
   depends_on "freetype"
   depends_on macos: :high_sierra # no access to sierra test box
   depends_on "open-mpi"

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -64,15 +64,15 @@ class Freecad < Formula
 
     prefix_paths = ""
     prefix_paths << (Formula["#{@tap}/qt5152"].opt_prefix/"lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/nglib"].opt_prefix/"Contents/Resources;")
+    prefix_paths << (Formula["#{@tap}/nglib@6.2.2104"].opt_prefix/"Contents/Resources;")
     prefix_paths << (Formula["#{@tap}/vtk@8.2.0"].opt_prefix/"lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/opencascade@7.5.0"].opt_prefix + "/lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/med-file"].opt_prefix + "/share/cmake/;")
-    prefix_paths << (Formula["#{@tap}/shiboken2"].opt_prefix + "/lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/pyside2"].opt_prefix+ "/lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/coin@4.0.0"].opt_prefix+ "/lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/boost@1.75.0"].opt_prefix+ "/lib/cmake;")
-    prefix_paths << (Formula["#{@tap}/boost-python3@1.75.0"].opt_prefix+ "/lib/cmake;")
+    prefix_paths << (Formula["#{@tap}/opencascade@7.5.3"].opt_prefix/"lib/cmake;")
+    prefix_paths << (Formula["#{@tap}/med-file"].opt_prefix/"share/cmake/;")
+    prefix_paths << (Formula["#{@tap}/shiboken2"].opt_prefix/"lib/cmake;")
+    prefix_paths << (Formula["#{@tap}/pyside2"].opt_prefix/"lib/cmake;")
+    prefix_paths << (Formula["#{@tap}/coin@4.0.0"].opt_prefix/"lib/cmake;")
+    prefix_paths << (Formula["#{@tap}/boost@1.75.0"].opt_prefix/"lib/cmake;")
+    prefix_paths << (Formula["#{@tap}/boost-python3@1.75.0"].opt_prefix/"lib/cmake;")
 
     # Disable function which are not available for Apple Silicon
     act = Hardware::CPU.arm? ? "OFF" : "ON"

--- a/Formula/nglib.rb
+++ b/Formula/nglib.rb
@@ -15,7 +15,7 @@ class Nglib < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "./opencascade@7.5.0"
+  depends_on "freecad/freecad/opencascade@7.5.3"
 
   def install
     cmake_prefix_path = Formula["#{@tap}/opencascade@7.5.0"].opt_prefix + "/lib/cmake;"

--- a/Formula/opencascade@7.5.0.rb
+++ b/Formula/opencascade@7.5.0.rb
@@ -20,7 +20,7 @@ class OpencascadeAT750 < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "rapidjson" => :build
-  depends_on "./tbb@2020_u3"
+  depends_on "freecad/freecad/tbb@2020_u3"
   depends_on "freeimage"
   depends_on "freetype"
 

--- a/Formula/pivy.rb
+++ b/Formula/pivy.rb
@@ -14,10 +14,10 @@ class Pivy < Formula
     sha256 cellar: :any, mojave:    "5671c1a87fd30a08c510b88a51bb1e210a65860f17f499f176ba04f63fae00b1"
   end
 
-  depends_on "./swig@4.0.2" => :build
+  depends_on "freecad/freecad/swig@4.0.2" => :build
   depends_on "cmake" => :build
   depends_on "freecad/freecad/python@3.9.6" => :build
-  depends_on "./coin@4.0.0"
+  depends_on "freecad/freecad/coin@4.0.0"
 
   def install
     system "python3", "setup.py", "install", "--prefix=#{prefix}"

--- a/Formula/pyside2-tools.rb
+++ b/Formula/pyside2-tools.rb
@@ -16,7 +16,7 @@ class Pyside2Tools < Formula
 
   depends_on "cmake" => :build
   depends_on "freecad/freecad/python@3.9.6" => :build
-  depends_on "./pyside2"
+  depends_on "freecad/freecad/pyside2"
 
   def install
     mkdir "macbuild3.9" do

--- a/Formula/qwtelmer.rb
+++ b/Formula/qwtelmer.rb
@@ -6,7 +6,7 @@ class Qwtelmer < Formula
   license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
   revision 1
 
-  depends_on "./qt5152"
+  depends_on "freecad/freecad/qt5152"
 
   # Update designer plugin linking back to qwt framework/lib after install
   # See: https://sourceforge.net/p/qwt/patches/45/

--- a/Formula/shiboken2.rb
+++ b/Formula/shiboken2.rb
@@ -15,8 +15,8 @@ class Shiboken2 < Formula
 
   depends_on "cmake" => :build
   depends_on "freecad/freecad/python@3.9.6" => :build
-  depends_on "./numpy@1.19.4"
-  depends_on "./qt5152"
+  depends_on "freecad/freecad/numpy@1.19.4"
+  depends_on "freecad/freecad/qt5152"
   depends_on "llvm"
 
   def install

--- a/Formula/vtk@8.2.0.rb
+++ b/Formula/vtk@8.2.0.rb
@@ -18,9 +18,9 @@ class VtkAT820 < Formula
   deprecate! date: "2020-05-14", because: :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "./boost@1.75.0"
-  depends_on "./pyqt@5.15.2"
-  depends_on "./qt5152"
+  depends_on "freecad/freecad/boost@1.75.0"
+  depends_on "freecad/freecad/pyqt@5.15.2"
+  depends_on "freecad/freecad/qt5152"
   depends_on "fontconfig"
   depends_on "freecad/freecad/python@3.9.6"
   depends_on "hdf5"


### PR DESCRIPTION
Fixes: "Another active Homebrew process is already in progress ..." error.

Testing and console output below based off of this invocation:

```
brew install freecad --HEAD --with-macos-app --build-from-source --verbose --debug
```

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

Passes

```
$ brew style freecad/freecad/freecad

1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

No output running this:

```
$ brew audit freecad/freecad/freecad
```

---

Am still getting this error -- which is probably related to [#163] and this commit comment: https://github.com/vejmarie/FreeCAD/commit/a5a448c85766d59bb3e71168906c704857a0db16#commitcomment-50072628

```
-- Installing: /usr/local/Cellar/freecad/HEAD-8527cab/FreeCAD.app/Contents/share/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
-- Installing: /usr/local/Cellar/freecad/HEAD-8527cab/FreeCAD.app/Contents/share/Gui/PreferencePackTemplates/Start_Colors.cfg
-- Installing: /usr/local/Cellar/freecad/HEAD-8527cab/FreeCAD.app/Contents/share/Gui/PreferencePackTemplates/TechDraw_Colors.cfg
-- Installing: /usr/local/Cellar/freecad/HEAD-8527cab/FreeCAD.app/Contents/share/Gui/PreferencePackTemplates/Window_Colors.cfg
CMake Error at src/MacAppBundle/cmake_install.cmake:55 (file):
  file INSTALL cannot find
  "/tmp/freecad-20211115-25671-s2gnxp/src/MacAppBundle/import site": No such
  file or directory.
Call Stack (most recent call first):
  src/cmake_install.cmake:51 (include)
  cmake_install.cmake:68 (include)


make: *** [install] Error 1
/usr/local/Homebrew/Library/Homebrew/shims/shared/git --version
/usr/local/Homebrew/Library/Homebrew/shims/shared/curl --version
/usr/local/Homebrew/Library/Homebrew/ignorable.rb:29:in `block in raise'
BuildError: Failed executing: make -j8 install
```

Am not sure if this is related to these warnings in the first two lines of this

```
Warning: Use freecad/freecad/python@3.9.6 instead of deprecated python3.9
Warning: Use freecad/freecad/python@3.9.6 instead of deprecated python3.9
==> cmake -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/freecad/HEAD-8527cab -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev -DBUILD_TESTING=OFF -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk -DBUILD_QT5=ON -DUSE_PYTHON3=1 -DCMAKE_CXX_STANDARD=17 -DBUILD_ENABLE_CXX_STD:STRING=C++17 -DBUILD_FEM_NETGEN=1 -DBUILD_FEM=1 -DBUILD_FEM_NETGEN:BOOL=ON -DBUILD_WEB=ON -DFREECAD_USE_EXTERNAL_KDL=ON -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=/usr/local/opt/python@3.9.6/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/local/opt/python@3.9.6/Frameworks/Python.framework/Headers -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5152/lib/cmake;/usr/local/opt/nglib@6.2.2104/Contents/Resources;/usr/local/opt/vtk@8.2.0/lib/cmake;/usr/local/opt/opencascade@7.5.3/lib/cmake;/usr/local/opt/med-file/share/cmake/;/usr/local/opt/shiboken2/lib/cmake;/usr/local/opt/pyside2/lib/cmake;/usr/local/opt/coin@4.0.0/lib/cmake;/usr/local/opt/boost@1.75.0/lib/cmake;/usr/local/opt/boost-python3@1.75.0/lib/cmake; -DFREECAD_CREATE_MAC_APP=1 ..
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Compiler: AppleClang, version: 13.0.0.13000029
-- Looking for GL/gl.h
-- Looking for GL/gl.h - not found
-- Looking for C++ include istream
-- Looking for C++ include istream - found
-- Looking for C++ include ostream
-- Looking for C++ include ostream - found
-- Looking for C++ include fstream
-- Looking for C++ include fstream - found
-- Looking for C++ include sstream
-- Looking for C++ include sstream - found
-- Looking for C++ include ios
-- Looking for C++ include ios - found
-- Looking for C++ include iostream
-- Looking for C++ include iostream - found
-- Looking for C++ include iomanip
-- Looking for C++ include iomanip - found
-- Looking for C++ include iostream
-- Looking for C++ include iostream - found
-- Check for STD namespace
-- Check for STD namespace - found
-- Force BOOST_PP_VARIADICS=1 for clang
-- prefix: /usr/local/Cellar/freecad/HEAD-8527cab
-- bindir: bin
-- datadir: share
-- docdir: share/doc/FreeCAD
-- includedir: include
-- libdir: lib
-- cmake: 3.21.4
-- Found Doxygen: /usr/local/bin/doxygen (found version "1.9.2") found components: doxygen dot 
-- Detected Homebrew install at /usr/local
-- Found Python3: /usr/local/bin/python3.9 (found version "3.9.6") found components: Interpreter Development Development.Module Development.Embed 
-- Found XercesC: /usr/local/lib/libxerces-c.dylib (found version "3.2.3") 
-- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/lib/libz.tbd (found version "1.2.11") 
-- PyCXX found:
--   Headers:  /tmp/freecad-20211115-25671-s2gnxp/src
--   Sources:  /tmp/freecad-20211115-25671-s2gnxp/src/CXX
--   Version:  6.2.8
-- Found OCC: /usr/local/opt/opencascade@7.5.3/include/opencascade (found version "7.5.3") 
-- -- Found OCE/OpenCASCADE version: 7.5.3
-- -- OCE/OpenCASCADE include directory: /usr/local/opt/opencascade@7.5.3/include/opencascade
-- -- OCE/OpenCASCADE shared libraries directory: /usr/local/opt/opencascade@7.5.3/lib
-- Found OpenGL: /Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/System/Library/Frameworks/OpenGL.framework   
-- Found OpenGLU: /Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/System/Library/Frameworks/OpenGL.framework
-- VTK components: vtkCommonCore;vtkCommonDataModel;vtkFiltersVerdict;vtkIOXML;vtkFiltersCore;vtkFiltersGeneral;vtkIOLegacy;vtkFiltersExtraction;vtkFiltersSources;vtkFiltersGeometry;vtkhdf5;vtkRenderingCore;vtkInteractionStyle;vtkRenderingFreeType;vtkRenderingOpenGL2
-- Check for medfile (libmed and libmedc) ...
-- Found MEDFile: /usr/local/include  
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.29.2") 
-- We guess that libmed was built using hdf5-serial version
-- Checking for one of the modules 'hdf5-serial'
-- Found HDF5: /usr/local/opt/hdf5@1.10/lib/libhdf5.dylib;/usr/local/lib/libsz.dylib;/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/lib/libz.tbd;/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/lib/libdl.tbd;/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/lib/libm.tbd (found version "1.10.7")  
-- Checking for one of the modules 'ompi-cxx'
-- Found Boost: /usr/local/opt/boost@1.75.0/lib/cmake/Boost-1.75.0/BoostConfig.cmake (found suitable version "1.75.0", minimum required is "1.55") found components: filesystem program_options regex system thread date_time 
-- Found Netgen: /usr/local/opt/nglib@6.2.2104/Contents/Resources/CMake
-- Performing Test CSTDIO_INCLUDE_TRY1
-- Performing Test CSTDIO_INCLUDE_TRY1 - Success
-- Found NETGEN version 6.2, calculated: 395832
-- Found SWIG: /usr/local/opt/swig@4.0.2/bin/swig (found version "4.0.2")  
-- Found Eigen3: /usr/local/include/eigen3 (found suitable version "3.4.0", minimum required is "2.91.0") 
-- Found Freetype: /usr/local/lib/libfreetype.dylib (found version "2.11.0") 
-- Coin3D libraries found
-- Found Spnav: /usr/local/lib/libspnav.dylib  
-- Shiboken2Config: Using default python: .cpython-39-darwin
-- Found PythonInterp: /usr/local/bin/python3.9 (found suitable version "3.9.6", minimum required is "3") 
-- Found PythonLibs: /usr/local/opt/python@3.9.6/Frameworks/Python.framework/Versions/3.9/lib/libpython3.9.dylib (found suitable version "3.9.6", minimum required is "3") 
-- SHIBOKEN_PYTHON_INCLUDE_DIRS computed to value: '/usr/local/opt/python@3.9.6/Frameworks/Python.framework/Headers'
-- SHIBOKEN_PYTHON_LIBRARIES computed to value: '-undefined dynamic_lookup'
-- libshiboken built for Release
-- PYTHON_CONFIG_SUFFIX: .cpython-39-darwin
-- libshiboken built for Release
-- ===============================================
PySide2 Python module found at /usr/local/lib/python3.9/site-packages/PySide2.
===============================================

-- Found Matplotlib: /usr/local/lib/python3.9/site-packages/matplotlib (found version "3.3.3")
-- Platform is 64-bit, set -D_OCC64
-- Performing Test _flag_found
-- Performing Test _flag_found - Success
-- Performing Test _flag_found
-- Performing Test _flag_found - Success
-- Performing Test _flag_found
-- Performing Test _flag_found - Success
```

The formula installs `six` and it appears in the correct `site-packages` directory -- so it seems that python@3.9.6 is being used.

```
$ ls -l /usr/local/lib/python3.9/site-packages/six.py
-rw-r--r--  1 stephen  admin  34549 Aug 16 14:03 /usr/local/lib/python3.9/site-packages/six.py
```

The cmake invocation looks like this (reformatted for readability):

```
=> cmake
  -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/freecad/HEAD-8527cab
  -DCMAKE_INSTALL_LIBDIR=lib
  -DCMAKE_BUILD_TYPE=Release
  -DCMAKE_FIND_FRAMEWORK=LAST
  -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev
  -DBUILD_TESTING=OFF
  -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk
  -DBUILD_QT5=ON
  -DUSE_PYTHON3=1
  -DCMAKE_CXX_STANDARD=17
  -DBUILD_ENABLE_CXX_STD:STRING=C++17
  -DBUILD_FEM_NETGEN=1
  -DBUILD_FEM=1
  -DBUILD_FEM_NETGEN:BOOL=ON
  -DBUILD_WEB=ON
  -DFREECAD_USE_EXTERNAL_KDL=ON
  -DCMAKE_BUILD_TYPE=Release
  -DPYTHON_EXECUTABLE=/usr/local/opt/python@3.9.6/bin/python3
  -DPYTHON_INCLUDE_DIR=/usr/local/opt/python@3.9.6/Frameworks/Python.framework/Headers
  -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5152/lib/cmake;
    /usr/local/opt/nglib@6.2.2104/Contents/Resources;
    /usr/local/opt/vtk@8.2.0/lib/cmake;
    /usr/local/opt/opencascade@7.5.3/lib/cmake;
    /usr/local/opt/med-file/share/cmake/;
    /usr/local/opt/shiboken2/lib/cmake;
    /usr/local/opt/pyside2/lib/cmake;
    /usr/local/opt/coin@4.0.0/lib/cmake;
    /usr/local/opt/boost@1.75.0/lib/cmake;
    /usr/local/opt/boost-python3@1.75.0/lib/cmake;
  -DFREECAD_CREATE_MAC_APP=1 ..
```

Asking python3 to report where it thinks `site-packages` is located:

```
$ python3 -c 'import site; print(site.getsitepackages())'
['/usr/local/Cellar/python@3.9.6/3.9.6_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages']
```

Which resolves to:

```
$ ls -l /usr/local/Cellar/python@3.9.6/3.9.6_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages
lrwxr-xr-x  1 stephen  admin  54 Nov 15 19:07 /usr/local/Cellar/python@3.9.6/3.9.6_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages -> ../../../../../../../../../lib/python3.9/site-packages
```