### PR TITLE
initial checkin of versioned pyside2@5.15.2

### DIFF
--- a/Formula/pyside2@5.15.2.rb
+++ b/Formula/pyside2@5.15.2.rb
@@ -1,0 +1,60 @@
+class Pyside2AT5152 < Formula
+  desc "Python bindings for Qt5 and greater"
+  homepage "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/README.pyside2.md?h=5.15.2"
+  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.2-src/pyside-setup-opensource-src-5.15.2.tar.xz"
+  sha256 "b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://github.com/FreeCAD/homebrew-freecad/releases/download/pyside2-5.15.2"
+    rebuild 1
+    sha256 big_sur:  "601d85682f44db6544b080492f5cb2fa9a184a32d231b04ed30558d1d342bdbb"
+    sha256 catalina: "4fc94bc33e858a5aac96073126cfe058bb8067c7a8654be0852ee63c38e47370"
+  end
+
+  keg_only :versioned_formula
+
+  option "without-docs", "Skip building documentation"
+
+  depends_on "cmake" => :build
+  depends_on "python@3.9" => :build
+  depends_on "sphinx-doc" => :build if build.with? "docs"
+  depends_on "freecad/freecad/shiboken2@5.15.2"
+  depends_on "qt@5"
+
+  def install
+    # This is a workaround for current problems with Shiboken2
+    ENV["HOMEBREW_INCLUDE_PATHS"] = ENV["HOMEBREW_INCLUDE_PATHS"].sub(Formula["qt@5"].include, "")
+
+    rm buildpath/"sources/pyside2/doc/CMakeLists.txt" if build.without? "docs"
+    # qt = Formula["#{@tap}/qt5152"]
+
+    # Add out of tree build because one of its deps, shiboken, itself needs an
+    # out of tree build in shiboken.rb.
+    pyhome = `#{Formula["python@3.9"].opt_bin}/python3.9-config --prefix`.chomp
+    py_library = "#{pyhome}/lib/libpython3.9.dylib"
+    py_include = "#{pyhome}/include/python3.9"
+
+    mkdir "macbuild3.9" do
+      ENV["LLVM_INSTALL_DIR"] = Formula["llvm"].opt_prefix
+      ENV["CMAKE_PREFIX_PATH"] = Formula["#{@tap}/shiboken2@5.15.2"].opt_prefix + "/lib/cmake"
+      args = std_cmake_args + %W[
+        -DPYTHON_EXECUTABLE=#{pyhome}/bin/python3.9
+        -DPYTHON_LIBRARY=#{py_library}
+        -DPYTHON_INCLUDE_DIR=#{py_include}
+        -DCMAKE_INSTALL_RPATH=#{lib}
+        -DCMAKE_BUILD_TYPE=Release
+      ]
+      args << "../sources/pyside2"
+      system "cmake", *args
+      system "make", "-j#{ENV.make_jobs}"
+      system "make", "install"
+    end
+  end
+
+  test do
+    Language::Python.each_python(build) do |python, _version|
+      system python, "-c", "from PySide2 import QtCore"
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
