### PR TITLE
[no ci] allow freecad app bundle to use libs with flat namespaces

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,18 +1,3 @@
 [
-  "adios2",
-  "arpack",
-  "bind",
-  "blast",
-  "coq",
-  "hdf5-mpi",
-  "libvirt",
-  "mpich",
-  "omniorb",
-  "open-mpi",
-  "pypy",
-  "pypy3",
-  "scalapack",
-  "soapysdr",
-  "tcl-tk",
-  "xvid"
+  "freecad"
 ]


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

**above checks are not applicable for this PR**

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
