### PR TITLE
add patch for elmer to use gcc version 11

### DIFF
--- a/patches/0001-ipatch-use-gcc-11.patch
+++ b/patches/0001-ipatch-use-gcc-11.patch
@@ -1,0 +1,29 @@
+From 05161eefacbc53956a5db7f0fa33527050d79a2f Mon Sep 17 00:00:00 2001
+From: chris <chris.r.jones.1983@gmail.com>
+Date: Wed, 8 Dec 2021 10:55:14 -0600
+Subject: [PATCH] ipatch, use gcc-11
+
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aa25bc2c..f970455c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,9 +14,9 @@ if(APPLE)
+   # message("you need to have gcc-gfrotran installed using HomeBrew")
+   # set(CMAKE_C_COMPILER "/usr/bin/gcc")
+   # set(CMAKE_CXX_COMPILER "/usr/bin/g++")
+-  set(CMAKE_C_COMPILER "/usr/local/bin/gcc-10")
+-  set(CMAKE_CXX_COMPILER "/usr/local/bin/g++-10")
+-  set(CMAKE_Fortran_COMPILER "/usr/local/bin/gfortran")
++  set(CMAKE_C_COMPILER "/usr/local/bin/gcc-11")
++  set(CMAKE_CXX_COMPILER "/usr/local/bin/g++-11")
++  set(CMAKE_Fortran_COMPILER "/usr/local/bin/gfortran-11")
+   # set(BLA_VENDOR "OpenBLAS")
+   # option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
+   # set (CMAKE_GENERATOR "Unix Makefiles" CACHE INTERNAL "" FORCE)
+-- 
+2.34.1
+


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

**NA**

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

**NA**

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
