### PR TITLE
shiboken2 python@3.10, specifically force limited API in cmake args

### DIFF
--- a/Formula/shiboken2-python3_10@5.15.2.rb
+++ b/Formula/shiboken2-python3_10@5.15.2.rb
@@ -47,6 +47,7 @@ class Shiboken2Python310AT5152 < Formula
       args << "-DPYTHON_EXECUTABLE=#{pyhome}/bin/python3.10"
       args << "-DPYTHON_LIBRARY=#{py_library}"
       args << "-DPYTHON_INCLUDE_DIR=#{py_include}"
+      args << "-DFORCE_LIMITED_API=1"
       args << "../sources/shiboken2"
 
       system "cmake", *args


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
