### PR TITLE
[no ci] checkin freecad v0.19.2 patch for mac app bundling

### DIFF
--- a/patches/freecad-0.19.2-mac-app-bundling.patch
+++ b/patches/freecad-0.19.2-mac-app-bundling.patch
@@ -1,0 +1,34 @@
+diff --git a/src/MacAppBundle/CMakeLists.txt b/src/MacAppBundle/CMakeLists.txt
+index c0b6ccf09f..b64cd761bf 100644
+--- a/src/MacAppBundle/CMakeLists.txt
++++ b/src/MacAppBundle/CMakeLists.txt
+@@ -112,16 +112,16 @@ install(CODE "execute_process(COMMAND chmod -R a+w ${CMAKE_INSTALL_LIBDIR})")
+ get_filename_component(APP_PATH ${CMAKE_INSTALL_PREFIX} PATH)
+
+ execute_process(
+-       COMMAND find /usr/local/Cellar/icu4c -name pkgconfig
+-       RESULT_VARIABLE CMD_ERROR
+-       OUTPUT_VARIABLE CONFIG_ICU)
++    COMMAND find ${HOMEBREW_PREFIX}/Cellar/icu4c -name pkgconfig
++    RESULT_VARIABLE CMD_ERROR
++    OUTPUT_VARIABLE CONFIG_ICU)
+ set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${CONFIG_ICU}")
+ find_package(PkgConfig)
+ pkg_check_modules(ICU icu-uc)
+
+ execute_process(
+-       COMMAND find /usr/local/Cellar/nglib -name MacOS
+-       OUTPUT_VARIABLE CONFIG_NGLIB)
++    COMMAND find ${HOMEBREW_PREFIX}/Cellar/nglib@6.2.2104 -name MacOS
++    OUTPUT_VARIABLE CONFIG_NGLIB)
+
+ install(CODE
+     "message(STATUS \"Making bundle relocatable...\")
+@@ -130,6 +130,6 @@ install(CODE
+     execute_process(
+         COMMAND python2.7
+         ${CMAKE_SOURCE_DIR}/src/Tools/MakeMacBundleRelocatable.py
+-        ${APP_PATH} ${HOMEBREW_PREFIX}${MACPORTS_PREFIX}/lib ${ICU_PREFIX}/lib/ /usr/local/opt ${CONFIG_NGLIB} ${Qt5Core_DIR}/../../.. ${XCTEST_PATH} ${WEBKIT_FRAMEWORK_DIR}
++        ${APP_PATH} /usr/lib ${HOMEBREW_PREFIX}${MACPORTS_PREFIX}/lib ${HOMEBREW_PREFIX}/opt/llvm@11/lib ${HOMEBREW_PREFIX}/opt/pyside2@5.15.2/lib/ ${HOMEBREW_PREFIX}/Cellar/icu4c/69.1/lib/ ${CONFIG_NGLIB} ${HOMEBREW_PREFIX}/opt ${HOMEBREW_PREFIX}/opt/opencascade@7.5.3/lib ${Qt5Core_DIR}/../../.. ${XCTEST_PATH} ${WEBKIT_FRAMEWORK_DIR}
+     )"
+ )


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

**NA**

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

**NA**

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
