### PR TITLE
[no ci] checkin my externally linked gist, of backported PR 4960 for …

### DIFF
--- a/patches/freecad-0.19.2-backport-of-PR4960.patch
+++ b/patches/freecad-0.19.2-backport-of-PR4960.patch
@@ -1,0 +1,36 @@
+diff -ruN FreeCAD-0.19.2/src/Mod/Cam/App/CMakeLists.txt FreeCAD-0.19.2.pr4960/src/Mod/Cam/App/CMakeLists.txt
+--- FreeCAD-0.19.2/src/Mod/Cam/App/CMakeLists.txt	2021-04-15 04:17:08.000000000 -0500
++++ FreeCAD-0.19.2.pr4960/src/Mod/Cam/App/CMakeLists.txt	2021-12-04 12:25:58.000000000 -0600
+@@ -14,7 +14,7 @@
+     ${OCC_INCLUDE_DIR}
+     ${ZLIB_INCLUDE_DIR}
+     ${PYTHON_INCLUDE_PATH}
+-    ${XERCESC_INCLUDE_DIR}
++    ${XercesC_INCLUDE_DIR}
+     ${UMFPACK_INCLUDE_DIR}
+     ${SMSH_INCLUDE_DIR}
+     ${SMESH_INCLUDE_DIR}
+diff -ruN FreeCAD-0.19.2/src/Mod/Cam/Gui/CMakeLists.txt FreeCAD-0.19.2.pr4960/src/Mod/Cam/Gui/CMakeLists.txt
+--- FreeCAD-0.19.2/src/Mod/Cam/Gui/CMakeLists.txt	2021-04-15 04:17:08.000000000 -0500
++++ FreeCAD-0.19.2.pr4960/src/Mod/Cam/Gui/CMakeLists.txt	2021-12-04 12:26:33.000000000 -0600
+@@ -13,7 +13,7 @@
+     ${PYTHON_INCLUDE_PATH}
+     ${QT_INCLUDE_DIR}
+     ${ZLIB_INCLUDE_DIR}
+-    ${XERCESC_INCLUDE_DIR}
++    ${XercesC_INCLUDE_DIR}
+     ${SMSH_INCLUDE_DIR}
+     ${SMESH_INCLUDE_DIR}
+ )
+diff -ruN FreeCAD-0.19.2/src/Mod/Measure/App/CMakeLists.txt FreeCAD-0.19.2.pr4960/src/Mod/Measure/App/CMakeLists.txt
+--- FreeCAD-0.19.2/src/Mod/Measure/App/CMakeLists.txt	2021-04-15 04:17:08.000000000 -0500
++++ FreeCAD-0.19.2.pr4960/src/Mod/Measure/App/CMakeLists.txt	2021-12-04 12:28:16.000000000 -0600
+@@ -13,7 +13,7 @@
+     ${OCC_INCLUDE_DIR}
+     ${ZLIB_INCLUDE_DIR}
+     ${PYTHON_INCLUDE_PATH}
+-    ${XERCESC_INCLUDE_DIR}
++    ${XercesC_INCLUDE_DIR}
+ )
+ link_directories(${OCC_LIBRARY_DIR})
+ 


### PR DESCRIPTION
…xerces-c fix

- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
