### PR TITLE
[no ci] update: stable version to 0.19.3

### DIFF
--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -7,8 +7,8 @@ class Freecad < Formula
 
   # NOTE: may require pointing to a specific tag / commit ???
   stable do
-    url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.19.2.tar.gz"
-    sha256 "47e39e3d6fcafe6e0c68923fb1b86acda16986268e5e6011694057b940139fba"
+    url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.19.3.tar.gz"
+    sha256 "568fa32a9601693ff9273f3a5a2e825915f58b2455ffa173bc23f981edecd07d"
   end
 
   # NOTE: freecad src has issues building macos app bundle, the gist patch...


### PR DESCRIPTION
Updating the stable version to the latest v0.19.3

---

- [] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
