### PR TITLE
add revision block to swig to rebuild bottles

### DIFF
--- a/Formula/swig@4.0.2.rb
+++ b/Formula/swig@4.0.2.rb
@@ -4,7 +4,8 @@ class SwigAT402 < Formula
   # NOTE: see github issue, https://github.com/swig/swig/issues/2069
   url "https://downloads.sourceforge.net/project/swig/swig/swig-4.0.2/swig-4.0.2.tar.gz"
   sha256 "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class SwigAT402 < Formula
   end
 
   head do
-    url "https://github.com/swig/swig.git"
+    url "https://github.com/swig/swig.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
