### PR TITLE
exp with setting an env var to build bottles for unsupported macos ve…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,15 @@ on:
       - master
 
   pull_request:
-  # workflow_dispatch:  # NOTE: nova with homebrew gha 
+  # workflow_dispatch:  # NOTE: nova with homebrew gha
 
 jobs:
   test-bot:
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-latest] # NOTE: default
-        # NOTE: homebrew-core uses private self hosted runner
-        # NOTE: `macOS-latest` default runner provided by github
+        # NOTE: homebrew-core uses private self hosted runners
+        # NOTE: `macOS-latest` is the default runner provided by github
         # os: [ self-hosted-catalinavm, self-hosted-bigsurvm ]
         os: [ self-hosted-catalinavm, self-hosted-bigsurvm, self-hosted-mojavevm ]
         # os: [ self-hosted-mojavevm ]
@@ -63,6 +63,15 @@ jobs:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
+
+      # NOTE: exp with using a condition to add env var for mojave runner
+      # SEE: https://docs.github.com/en/actions/learn-github-actions/environment-variables
+      #
+      # NOTE: may require using `RUNNER_NAME` instead of `runner.os`
+      - name: condition 1
+        if: runner.os == 'self-hosted-mojavevm'
+        run: echo "The operating system on the runner is, $RUNNER_OS."
+        run: export HOMEBREW_DEVELOPER=1
 
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true' && steps.last_run_status.outputs.last_run_status != 'success'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,9 @@ jobs:
       # NOTE: may require using `RUNNER_NAME` instead of `runner.os`
       - name: condition 1
         if: runner.os == 'self-hosted-mojavevm'
-        run: echo "The operating system on the runner is, $RUNNER_OS."
-        run: export HOMEBREW_DEVELOPER=1
+        run: echo "The operating system on the runner is, $RUNNER_OS."; echo HOMEBREW_DEVELOPER=1 >> $GITHUB_ENV
+        # NOTE: not possible to have two `run:` blocks within a `name`
+        # run: export HOMEBREW_DEVELOPER=1
 
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true' && steps.last_run_status.outputs.last_run_status != 'success'


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
