### PR TITLE
[no ci] exp with alt homebrew-core repo for mojave

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,13 +69,13 @@ jobs:
       #
       # NOTE: may require using `RUNNER_NAME` instead of `runner.os`
       - name: condition 1
-        if: runner.os == 'self-hosted-mojavevm'
+        if: runner.name == 'self-hosted-mojavevm'
         run: echo "The operating system on the runner is, $RUNNER_OS."; echo HOMEBREW_DEVELOPER=1 >> $GITHUB_ENV
         # NOTE: not possible to have two `run:` blocks within a `name`
         # run: export HOMEBREW_DEVELOPER=1
 
       - name: condition 2
-        if: runner.os == 'self-hosted-mojavevm'
+        if: runner.name == 'self-hosted-mojavevm'
         run: echo HOMEBREW_CORE_GIT_REMOTE=https://github.com/gromgit/homebrew-core-mojave
 
       - name: Install Homebrew Bundler RubyGems

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,13 +72,13 @@ jobs:
       #
       # NOTE: may require using `RUNNER_NAME` instead of `runner.os`
       - name: condition 1
-        if: runner.name == 'self-hosted-mojavevm'
+        if: runner.name == 'vmmojave'
         run: echo "The operating system on the runner is, $RUNNER_OS."; echo HOMEBREW_DEVELOPER=1 >> $GITHUB_ENV
         # NOTE: not possible to have two `run:` blocks within a `name`
         # run: export HOMEBREW_DEVELOPER=1
 
       - name: condition 2
-        if: runner.name == 'self-hosted-mojavevm'
+        if: runner.name == 'vmmojave'
         run: echo HOMEBREW_CORE_GIT_REMOTE=https://github.com/gromgit/homebrew-core-mojave
 
       - name: Install Homebrew Bundler RubyGems

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,9 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
+      - name: print env
+        run: env
+
       # NOTE: exp with using a condition to add env var for mojave runner
       # SEE: https://docs.github.com/en/actions/learn-github-actions/environment-variables
       #


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
