### PR TITLE
[no ci] exp with adding a patch for shiboken2 to work with numpy v1.23

### DIFF
--- a/patches/0001-patch-sbknumpyarrayconverter.cpp-for-shiboken2-with-.patch
+++ b/patches/0001-patch-sbknumpyarrayconverter.cpp-for-shiboken2-with-.patch
@@ -1,0 +1,31 @@
+From 5dbcdc8ef4a20b4715cef65b253a003f2f3dc445 Mon Sep 17 00:00:00 2001
+From: chris <chris.r.jones.1983@gmail.com>
+Date: Wed, 6 Jul 2022 20:05:01 -0500
+Subject: [PATCH] patch sbknumpyarrayconverter.cpp for shiboken2 with numpy
+ v1.23
+
+---
+ sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp b/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
+index 996968f..cc25b34 100644
+--- a/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
++++ b/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
+@@ -116,8 +116,13 @@ std::ostream &operator<<(std::ostream &str, PyArrayObject *o)
+             str << " NPY_ARRAY_NOTSWAPPED";
+         if ((flags & NPY_ARRAY_WRITEABLE) != 0)
+             str << " NPY_ARRAY_WRITEABLE";
++#if NPY_VERSION >= 0x00000010 // NPY_1_23_API_VERSION
++        if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) != 0)
++            str << " NPY_ARRAY_WRITEBACKIFCOPY";
++#else
+         if ((flags & NPY_ARRAY_UPDATEIFCOPY) != 0)
+             str << " NPY_ARRAY_UPDATEIFCOPY";
++#endif
+     } else {
+         str << '0';
+     }
+-- 
+2.37.0
+


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
