### PR TITLE
attempt to fix sbknumpyarrayconverter.cpp patch

### DIFF
--- a/patches/0001-patch-sbknumpyarrayconverter.cpp-for-shiboken2-with-.patch
+++ b/patches/0001-patch-sbknumpyarrayconverter.cpp-for-shiboken2-with-.patch
@@ -20,8 +20,8 @@ index 996968f..cc25b34 100644
 +        if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) != 0)
 +            str << " NPY_ARRAY_WRITEBACKIFCOPY";
 +#else
-         if ((flags & NPY_ARRAY_UPDATEIFCOPY) != 0)
-             str << " NPY_ARRAY_UPDATEIFCOPY";
++        if ((flags & NPY_ARRAY_UPDATEIFCOPY) != 0)
++            str << " NPY_ARRAY_UPDATEIFCOPY";
 +#endif
      } else {
          str << '0';


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
