### PR TITLE
[no ci] checkin patch files for shiboken2

### DIFF
--- a/patches/shiboken2-pep384impl.patch
+++ b/patches/shiboken2-pep384impl.patch
@@ -1,0 +1,79 @@
+--- a/sources/shiboken2/libshiboken/pep384impl.cpp
++++ b/sources/shiboken2/libshiboken/pep384impl.cpp
+@@ -707,6 +707,76 @@
+  *
+  */
+ 
++#if PY_VERSION_HEX >= 0x03000000
++PyObject *
++_Py_Mangle(PyObject *privateobj, PyObject *ident)
++{
++    /* Name mangling: __private becomes _classname__private.
++       This is independent from how the name is used. */
++    PyObject *result;
++    size_t nlen, plen, ipriv;
++    Py_UCS4 maxchar;
++    if (privateobj == NULL || !PyUnicode_Check(privateobj) ||
++        PyUnicode_READ_CHAR(ident, 0) != '_' ||
++        PyUnicode_READ_CHAR(ident, 1) != '_') {
++        Py_INCREF(ident);
++        return ident;
++    }
++    nlen = PyUnicode_GET_LENGTH(ident);
++    plen = PyUnicode_GET_LENGTH(privateobj);
++    /* Don't mangle __id__ or names with dots.
++
++       The only time a name with a dot can occur is when
++       we are compiling an import statement that has a
++       package name.
++
++       TODO(jhylton): Decide whether we want to support
++       mangling of the module name, e.g. __M.X.
++    */
++    if ((PyUnicode_READ_CHAR(ident, nlen-1) == '_' &&
++         PyUnicode_READ_CHAR(ident, nlen-2) == '_') ||
++        PyUnicode_FindChar(ident, '.', 0, nlen, 1) != -1) {
++        Py_INCREF(ident);
++        return ident; /* Don't mangle __whatever__ */
++    }
++    /* Strip leading underscores from class name */
++    ipriv = 0;
++    while (PyUnicode_READ_CHAR(privateobj, ipriv) == '_')
++        ipriv++;
++    if (ipriv == plen) {
++        Py_INCREF(ident);
++        return ident; /* Don't mangle if class is just underscores */
++    }
++    plen -= ipriv;
++
++    if (plen + nlen >= PY_SSIZE_T_MAX - 1) {
++        PyErr_SetString(PyExc_OverflowError,
++                        "private identifier too large to be mangled");
++        return NULL;
++    }
++
++    maxchar = PyUnicode_MAX_CHAR_VALUE(ident);
++    if (PyUnicode_MAX_CHAR_VALUE(privateobj) > maxchar)
++        maxchar = PyUnicode_MAX_CHAR_VALUE(privateobj);
++
++    result = PyUnicode_New(1 + nlen + plen, maxchar);
++    if (!result)
++        return 0;
++    /* ident = "_" + priv[ipriv:] + ident # i.e. 1+plen+nlen bytes */
++    PyUnicode_WRITE(PyUnicode_KIND(result), PyUnicode_DATA(result), 0, '_');
++    if (PyUnicode_CopyCharacters(result, 1, privateobj, ipriv, plen) < 0) {
++        Py_DECREF(result);
++        return NULL;
++    }
++    if (PyUnicode_CopyCharacters(result, plen+1, ident, 0, nlen) < 0) {
++        Py_DECREF(result);
++        return NULL;
++    }
++    assert(_PyUnicode_CheckConsistency(result, 1));
++    return result;
++}
++#endif
++
+ #ifdef Py_LIMITED_API
+ // We keep these definitions local, because they don't work in Python 2.
+ # define PyUnicode_GET_LENGTH(op)    PyUnicode_GetLength((PyObject *)(op))

--- a/patches/shiboken2-sbknumpyarrayconverter.patch
+++ b/patches/shiboken2-sbknumpyarrayconverter.patch
@@ -1,8 +1,7 @@
-From 5dbcdc8ef4a20b4715cef65b253a003f2f3dc445 Mon Sep 17 00:00:00 2001
+From 0edaa3f9fa74aa99dd25aa9df805be0291995f40 Mon Sep 17 00:00:00 2001
 From: chris <chris.r.jones.1983@gmail.com>
-Date: Wed, 6 Jul 2022 20:05:01 -0500
-Subject: [PATCH] patch sbknumpyarrayconverter.cpp for shiboken2 with numpy
- v1.23
+Date: Fri, 15 Jul 2022 14:20:53 -0500
+Subject: [PATCH] sbknumpyarrayconverter patch for shiboken2
 
 ---
  sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp | 5 +++++
@@ -14,18 +13,18 @@ index 996968f..cc25b34 100644
 +++ b/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
 @@ -116,8 +116,13 @@ std::ostream &operator<<(std::ostream &str, PyArrayObject *o)
              str << " NPY_ARRAY_NOTSWAPPED";
--         if ((flags & NPY_ARRAY_WRITEABLE) != 0)
--             str << " NPY_ARRAY_WRITEABLE";
+         if ((flags & NPY_ARRAY_WRITEABLE) != 0)
+             str << " NPY_ARRAY_WRITEABLE";
 +#if NPY_VERSION >= 0x00000010 // NPY_1_23_API_VERSION
 +        if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) != 0)
 +            str << " NPY_ARRAY_WRITEBACKIFCOPY";
 +#else
-+        if ((flags & NPY_ARRAY_UPDATEIFCOPY) != 0)
-+            str << " NPY_ARRAY_UPDATEIFCOPY";
+         if ((flags & NPY_ARRAY_UPDATEIFCOPY) != 0)
+             str << " NPY_ARRAY_UPDATEIFCOPY";
 +#endif
      } else {
          str << '0';
      }
 -- 
-2.37.0
+2.37.1
 


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
