### PR TITLE
freecad.rb update file to work with m1 and 0.20 release

### DIFF
--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -77,6 +77,7 @@ class Elmer < Formula
 
   def caveats
     <<-EOS
+    complete at a later date
     EOS
   end
 

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -1,92 +1,92 @@
 class Freecad < Formula
   desc "Parametric 3D modeler"
   homepage "https://www.freecadweb.org"
-  version "0.19"
   license "GPL-2.0-only"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 
-  # NOTE: may require pointing to a specific tag / commit ???
   stable do
-    url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.19.3.tar.gz"
-    sha256 "568fa32a9601693ff9273f3a5a2e825915f58b2455ffa173bc23f981edecd07d"
+    url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.20.tar.gz"
+    sha256 "c4d9ce782d3da0edfa16d6218db4ce8613e346124ee47b3fe6a6dae40c0a61d9"
   end
 
-  # NOTE: freecad src has issues building macos app bundle, the gist patch...
-  # ...aims to address those issues.
-  # NOTE: in the future the gist patch should remove hard coded paths
-  stable do
-    patch do
-      url "https://gist.githubusercontent.com/ipatch/b32ceefc45fb84341cd5565caaed7e71/raw/cbef7ab55d9dd4d6d4d677f7269e0b70b05698b2/patch"
-      sha256 "00e406b2b6603735195f4114f968890e45447e5146c38c5a1906af38a5606fde"
-    end
-
-    patch do
-      url "https://gist.githubusercontent.com/ipatch/b32ceefc45fb84341cd5565caaed7e71/raw/5699d9cdbdb127ef19aec26e63070f59ac128261/backport%2520of%2520PR%2520%25234960"
-      sha256 "97a5be2d0a69f96ba880236f6d052b744323edf63c9ace573c85c0682ebabe7f"
-    end
-  end
-
-  bottle do
-    root_url "https://github.com/FreeCAD/homebrew-freecad/releases/download/freecad-0.19"
-    rebuild 3
-    sha256 big_sur:  "413f29de4ffabb64bb5c90d9ec7b338c98b7b7a20689c3040336bf6627bd906f"
-    sha256 catalina: "d8a4caa617ba25a86a363142e4db8a6e07c496c0453034aac5918fb0444c1fb1"
-  end
-
-  option "with-no-macos-app", "launch FreeCAD from CLI"
+  option "with-macos-app", "Create FreeCAD.app bundle"
   option "with-cloud", "Build with CLOUD module"
   option "with-unsecured-cloud", "Build with self signed certificate support CLOUD module"
-  option "with-skip-web", "Disable web"
+  # option "with-skip-web", "Disable web"
 
   depends_on "cmake" => :build
-  depends_on "hdf5@1.10" => :build
+  depends_on "hdf5" => :build
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
-  depends_on "tbb@2020" => :build
+  depends_on "tbb" => :build
   depends_on "boost"
   depends_on "boost-python3"
   depends_on "coin3d"
   depends_on "cython"
   depends_on "doxygen"
-  depends_on "freecad/freecad/matplotlib@3.4.3"
-  depends_on "freecad/freecad/med-file@4.1.0"
-  depends_on "freecad/freecad/nglib@6.2.2104"
-  depends_on "freecad/freecad/opencascade@7.5.3"
-  depends_on "freecad/freecad/pyside2@5.15.2"
-  depends_on "freecad/freecad/shiboken2@5.15.2"
+  depends_on "freecad/freecad/med-file"
+  depends_on "freecad/freecad/pyside2@5.15.5"
+  depends_on "freecad/freecad/shiboken2@5.15.5"
   depends_on "freetype"
   depends_on "icu4c"
-  depends_on "llvm@11"
+  # epends_on "freecad/freecad/nglib@6.2.2105"
+  depends_on "llvm"
   depends_on macos: :high_sierra # no access to sierra test box
   depends_on "openblas"
+  depends_on "opencascade"
   depends_on "orocos-kdl"
   depends_on "pkg-config"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "qt@5"
-  depends_on "vtk@8.2"
+  depends_on "vtk"
   depends_on "webp"
   depends_on "xerces-c"
 
+  # NOTE: `brew update-python-resources` check for outdated py resources
+  resource "matplotlib" do
+    url "https://files.pythonhosted.org/packages/8a/46/425a44ab9a71afd2f2c8a78b039c1af8ec21e370047f0ad6e43ca819788e/matplotlib-3.5.1.tar.gz"
+    sha256 "b2e9810e09c3a47b73ce9cab5a72243a1258f61e7900969097a817232246ce1c"
+  end
+
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz"
+    sha256 "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
+  end
+
+  # TODO: double check patches
+  # TODO: make a macos mojave specific patch
+  # NOTE: https://docs.brew.sh/Formula-Cookbook#handling-different-system-configurations
+  patch do
+    url "https://github.com/ipatch/FreeCAD/commit/68840f90002a8d6cb40fda9c867b87775cf25c8d.patch?full_index=1"
+    sha256 "4a95bdebe444b441243221298748552b17f65b7ec14abce35ef35db509724e9e"
+  end
+
+  patch do
+    url "https://github.com/ipatch/FreeCAD/commit/fa5a7415d295ae16adc4ba34159f290c5f9c9bff.patch?full_index=1"
+    sha256 "45cb9f8c237c0f2eedbb5687033683cc48fca1df0926c069c7d31e756a118455"
+  end
+
+  def python3
+    deps.map(&:to_formula)
+        .find { |f| f.name.match?(/^python@\d\.\d+$/) }
+        .opt_bin/"python3"
+  end
+
   def install
-    unless File.exist?("#{HOMEBREW_PREFIX}/lib/python3.9/site-packages/PySide2/__init__.py")
-      system "pip3", "install", "PySide2"
-    end
-
     # Disable function which are not available for Apple Silicon
-    act = Hardware::CPU.arm? ? "OFF" : "ON"
-    web = build.with?("skip-web") ? "OFF" : act
+    # act = Hardware::CPU.arm? ? "OFF" : "ON"
+    # web = build.with?("skip-web") ? "OFF" : act
 
-    # NOTE: adding pyside2 the cmake_prefix_path does not help cmake in finding pyside2
-    pth_pyside2 = Formula["pyside2@5.15.2"].opt_prefix
-
-    # NOTE: order determined based on cmake checks
+    # NOTE: ordered loosely by cmake checks
     hbp = HOMEBREW_PREFIX
     pth_xercesc = Formula["xerces-c"].opt_prefix
-    pth_occ = Formula["opencascade@7.5.3"].opt_prefix
-    pth_hdf5 = Formula["hdf5@1.10"].opt_prefix
+    pth_occ = Formula["opencascade"].opt_prefix
+    pth_hdf5 = Formula["hdf5"].opt_prefix
     pth_coin = Formula["coin3d"].opt_prefix
+    pth_pyside2 = "#{Formula["#{@tap}/pyside2@5.15.5"].prefix}/lib/cmake/PySide2-5.15.5"
     pth_qt5 = Formula["qt@5"].opt_prefix
-    pth_vtk = Formula["vtk@8.2"].opt_prefix
+    pth_vtk = Formula["vtk"].opt_prefix
+    pth_med = Formula["freecad/freecad/med-file"].opt_prefix
 
     cmake_prefix_paths = "\""
     cmake_prefix_paths << "#{pth_xercesc};"
@@ -96,42 +96,55 @@ class Freecad < Formula
     cmake_prefix_paths << "#{pth_qt5};"
     cmake_prefix_paths << "#{pth_vtk};"
     cmake_prefix_paths << "#{pth_pyside2};"
+    cmake_prefix_paths << "#{pth_med};"
     cmake_prefix_paths << "\""
 
     args = std_cmake_args + %W[
       -DHOMEBREW_PREFIX=#{hbp}
-      -DUSE_PYTHON3=1
       -DPYTHON_EXECUTABLE=#{hbp}/bin/python3
-      -DPYTHON_INCLUDE_DIR=#{hbp}/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9
-      -DPYTHON_LIBRARY=#{hbp}/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/libpython3.9.dylib
+      -DPYTHON_INCLUDE_DIR=#{hbp}/opt/python@3.10/Frameworks/Python.framework/Headers
+      -DPYTHON_LIBRARY=#{hbp}/opt/python@3.10/Frameworks/Python.framework/Versions/Current/lib/libpython3.10.dylib
       -DBUILD_SMESH=1
-      -DBUILD_WEB=#{web}
       -DBUILD_QT5=1
       -DFREECAD_USE_EXTERNAL_KDL=1
-      -DBUILD_FEM=1
       -DBUILD_FEM_NETGEN=0
       -DBUILD_ENABLE_CXX_STD=C++17
       -DCMAKE_PREFIX_PATH=#{cmake_prefix_paths}
     ]
+    # NOTE: below two args useful for debugging
+    # --trace
+    # -L
 
-    args << if build.with? "no-macos-app"
-      "-DFREECAD_CREATE_MAC_APP=0"
-    else
+    args << if build.with? "macos-app"
       "-DFREECAD_CREATE_MAC_APP=1"
+    else
+      "-DFREECAD_CREATE_MAC_APP=0"
+      # bin.install_symlink "../MacOS/FreeCAD" => "FreeCAD"
+      # bin.install_symlink "../MacOS/FreeCADCmd" => "FreeCADCmd"
+      # (lib/"python3.10/site-packages/homebrew-freecad-bundle.pth").write "#{prefix}/MacOS/\n"
     end
 
     args << "-DBUILD_CLOUD=1" if build.with? "cloud"
     args << "-DALLOW_SELF_SIGNED_CERTIFICATE=1" if build.with? "unsecured-cloud"
 
+    ENV.prepend_path "PATH", Formula["shiboken2@5.15.5"].prefix/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_prefix/"bin"
+
+    ENV.remove "PATH", Formula["pyside@2"].opt_prefix/"bin"
+    # ENV.remove "PATH", Formula["python@3.9"].opt_prefix/"bin"
+
+    # for reasons i dont understand pyside@2 is sneaking into the cmake_prefix_path
+    ENV.remove "CMAKE_PREFIX_PATH", Formula["pyside@2"].prefix
+    ENV.remove "PKG_CONFIG_PATH", Formula["pyside@2"].opt_prefix/"lib/pkgconfig"
+
+    # NOTE: ipatch, exp with PYTHONPATH
+    ENV.prepend_path "PYTHONPATH", Formula["shiboken2@5.15.5"].opt_prefix/Language::Python.site_packages(python3)
+    ENV.prepend_path "PYTHONPATH", Formula["pyside2@5.15.5"].opt_prefix/Language::Python.site_packages(python3)
+
+    # TODO: ipatch, do not make build dir a sub dir of the src dir
     mkdir "Build" do
       system "cmake", *args, ".."
       system "make", "install"
-    end
-
-    args << if build.with? "no-macos-app"
-      bin.install_symlink "../MacOS/FreeCAD" => "FreeCAD"
-      bin.install_symlink "../MacOS/FreeCADCmd" => "FreeCADCmd"
-      (lib/"python3.9/site-packages/homebrew-freecad-bundle.pth").write "#{prefix}/MacOS/\n"
     end
   end
 
@@ -143,15 +156,12 @@ class Freecad < Formula
        the FreeCAD directory
          export PYTHONPATH=#{bin}:$PYTHONPATH
 
-    2. Due to the inordinate amount of dependencies in this formula
-       FreeCAD is built into a self contained Apple .app bundle.
-       After the installation has completed please drag n drop
-       the FreeCAD.app bundle to the /Applications/ directory.
-
-    3. Due to the large amount of dependenices and rapid updates
-       of such dependenices I chose to make this formula a self
-       contained .app bundle to hopefully prevent constant
-       breakage of the app.
+    2. Due to recent code signing updates with Catalina and newer
+       building a FreeCAD.app bundle using the existing python
+       script no longer works due to updating the rpaths of the
+       copied executables and libraries into a FreeCAD.app
+       bundle. Until a fix or work around is made freecad
+       is built for CLI by default now.
     EOS
   end
 

--- a/Formula/freecad.rb
+++ b/Formula/freecad.rb
@@ -12,7 +12,6 @@ class Freecad < Formula
   option "with-macos-app", "Create FreeCAD.app bundle"
   option "with-cloud", "Build with CLOUD module"
   option "with-unsecured-cloud", "Build with self signed certificate support CLOUD module"
-  # option "with-skip-web", "Disable web"
 
   depends_on "cmake" => :build
   depends_on "hdf5" => :build

--- a/Formula/pyside2@5.15.5.rb
+++ b/Formula/pyside2@5.15.5.rb
@@ -7,9 +7,7 @@ class Pyside2AT5155 < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"
-    if MacOS.version == :mojave
-      rebuild 1
-    end
+    rebuild 1 if MacOS.version == :mojave
     sha256 cellar: :any, big_sur:  "609b5396a299fe1a3a9a0b98d5edb8596cba10619b2794d937bfee3d4c735ee5"
     sha256 cellar: :any, catalina: "cb9c38024167a60647177545570a09beb3033a178367fb17a1e0e63fd9186fc7"
     sha256 cellar: :any, mojave:   "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"

--- a/Formula/pyside2@5.15.5.rb
+++ b/Formula/pyside2@5.15.5.rb
@@ -7,10 +7,14 @@ class Pyside2AT5155 < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"
-    rebuild 1 if MacOS.version == :mojave
     sha256 cellar: :any, big_sur:  "609b5396a299fe1a3a9a0b98d5edb8596cba10619b2794d937bfee3d4c735ee5"
     sha256 cellar: :any, catalina: "cb9c38024167a60647177545570a09beb3033a178367fb17a1e0e63fd9186fc7"
-    sha256 cellar: :any, mojave:   "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"
+  end
+
+  bottle do
+    root_url "https://ghcr.io/v2/freecad/freecad"
+    rebuild 1 if MacOS.version == :mojave
+    sha256 cellar: :any, mojave: "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"
   end
 
   keg_only :versioned_formula

--- a/Formula/pyside2@5.15.5.rb
+++ b/Formula/pyside2@5.15.5.rb
@@ -7,8 +7,12 @@ class Pyside2AT5155 < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"
+    if MacOS.version == :mojave
+      rebuild 1
+    end
     sha256 cellar: :any, big_sur:  "609b5396a299fe1a3a9a0b98d5edb8596cba10619b2794d937bfee3d4c735ee5"
     sha256 cellar: :any, catalina: "cb9c38024167a60647177545570a09beb3033a178367fb17a1e0e63fd9186fc7"
+    sha256 cellar: :any, mojave:   "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"
   end
 
   keg_only :versioned_formula

--- a/casks/freecad.rb
+++ b/casks/freecad.rb
@@ -5,7 +5,7 @@ cask "freecad" do
   sha256 "3a393e807331ed3c9303037095423a6036a23ab00af7c7836e5c19c5a5321b73"
 
   url "https://github.com/freecad/homebrew-freecad/releases/download/#{version.major_minor_patch}.release/FreeCAD-#{version.major_minor}-release.dmg",
-    verified: "github.com/freecad/homebrew-freecad"
+      verified: "github.com/freecad/homebrew-freecad"
   name "FreeCAD"
   desc "3D parametric modler"
   homepage "https://www.freecad.org/"


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
