### PR TITLE
fix style errors to make test-bot happy for freecad.rb [no ci]

### DIFF
--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -77,6 +77,7 @@ class Elmer < Formula
 
   def caveats
     <<-EOS
+    complete at a later date
     EOS
   end
 

--- a/Formula/pyside2@5.15.5.rb
+++ b/Formula/pyside2@5.15.5.rb
@@ -7,9 +7,7 @@ class Pyside2AT5155 < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"
-    if MacOS.version == :mojave
-      rebuild 1
-    end
+    rebuild 1 if MacOS.version == :mojave
     sha256 cellar: :any, big_sur:  "609b5396a299fe1a3a9a0b98d5edb8596cba10619b2794d937bfee3d4c735ee5"
     sha256 cellar: :any, catalina: "cb9c38024167a60647177545570a09beb3033a178367fb17a1e0e63fd9186fc7"
     sha256 cellar: :any, mojave:   "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"

--- a/casks/freecad.rb
+++ b/casks/freecad.rb
@@ -5,7 +5,7 @@ cask "freecad" do
   sha256 "3a393e807331ed3c9303037095423a6036a23ab00af7c7836e5c19c5a5321b73"
 
   url "https://github.com/freecad/homebrew-freecad/releases/download/#{version.major_minor_patch}.release/FreeCAD-#{version.major_minor}-release.dmg",
-    verified: "github.com/freecad/homebrew-freecad"
+      verified: "github.com/freecad/homebrew-freecad"
   name "FreeCAD"
   desc "3D parametric modler"
   homepage "https://www.freecad.org/"


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
