### PR TITLE
Clarify --with-macos-app install flag [no ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ brew install --only-dependencies freecad
 
 #### Install flags
 
-`--with-no-macos-app` brew will install freecad as binary to be launched from a CLI
+By default, freecad is installed as a binary to be launched from a CLI. To also create a .app bundle use `--with-macos-app`.
 
 ## Building The Current Release Version of FreeCAD
 


### PR DESCRIPTION
There is no --with-no-macos-app install flag. I removed this install flag and clarified the usage of --with-macos-app.