### PR TITLE
[no ci] possible syntax err

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
         # NOTE: not possible to have two `run:` blocks within a `name`
 
       # attempt reset env var that appears to be not resetting
-      - name: condition 1.1
+      - name: condition 1_1
         if: runner.name = 'vmmojave'
         run: echo HOMEBREW_CORE_GIT_REMOTE=https://github.com/homebrew/homebrew-core >> $GITHUB_ENV
 


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
