### PR TITLE
swig: add caveats section to formula file

### DIFF
--- a/Formula/swig@4.1.1.rb
+++ b/Formula/swig@4.1.1.rb
@@ -10,6 +10,12 @@ class SwigAT411 < Formula
     url :stable
   end
 
+  bottle do
+    root_url "https://ghcr.io/v2/freecad/freecad"
+    sha256 big_sur: "268482d8e66c75b08f99380f17d83f613e7a92ddab1912171fdd9fc2385b6c2f"
+    sha256 mojave:  "29d6d2472f32f91fef5686de1082c18407c47e3625c5dca71e48d757a7aba93e"
+  end
+
   head do
     url "https://github.com/swig/swig.git", branch: "master"
 
@@ -29,6 +35,13 @@ class SwigAT411 < Formula
                           "--prefix=#{prefix}"
     system "make"
     system "make", "install"
+  end
+
+  def caveats
+    <<-EOS
+    this formula is keg only due to same formula
+    being in the homebrew-core main repo
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
