### PR TITLE
[no ci] update tests.yml to remove deprecated cmds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,13 +32,15 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
+        # run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
       - name: Log date
         run: echo "${{ steps.date.outputs.date }}"
 
       - name: Set default run status
-        run: echo "::set-output name=last_run_status::default" > last_run_status
+        # run: echo "::set-output name=last_run_status::default" > last_run_status
+        run: echo "last_run_status=default" >> $GITHUB_ENV
 
       - name: Restore last run status
         id: last_run
@@ -114,4 +116,7 @@ jobs:
 
       - name: Save run status
         if: steps.last_run_status.outputs.last_run_status != 'success'
-        run: echo "::set-output name=last_run_status::${{ steps.test_run.outcome }}" > last_run_status
+        # run: echo "::set-output name=last_run_status::${{ steps.test_run.outcome }}" > last_run_status
+        run: echo "last_run_status=${{ steps.test_run.outcome }}" >> $GITHUB_ENV
+
+


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

NA

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

NA

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
