### PR TITLE
swig rm excess bottle block for catalina [no ci]

### DIFF
--- a/Formula/swig@4.1.1.rb
+++ b/Formula/swig@4.1.1.rb
@@ -18,12 +18,6 @@ class SwigAT411 < Formula
     sha256 mojave:   "bb3ebba5810a08e0148a12b09359da2cd6868a69126a3d059e4bc4dc3e37cd0f"
   end
 
-  bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    rebuild 2 if MacOS.version == :catalina
-    sha256 catalina: "2d4c1fd6521af80b4867cf0e24f83fee67b7dd5cc4a8e8e61888a7e6a1be4eb1"
-  end
-
   head do
     url "https://github.com/swig/swig.git", branch: "master"
 


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
