### PR TITLE
initial checkin for new shiboken version

### DIFF
--- a/Formula/shiboken2@5.15.11.rb
+++ b/Formula/shiboken2@5.15.11.rb
@@ -1,0 +1,53 @@
+class Shiboken2AT51511 < Formula
+  desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
+  homepage "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/README.shiboken2-generator.md?h=5.15.2"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+  revision 1
+  head "https://github.com/qt/qt5.git", branch: "dev", shallow: false
+
+  stable do
+    url "https://download.qt.io/official_releases/QtForPython/shiboken2/PySide2-5.15.11-src/pyside-setup-opensource-src-5.15.11.zip"
+    sha256 "9bf6d4f3192697b8d5d7e92219c8d964dcfbfe96a438916bb1cdb78265584081"
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "python@3.10" => :build
+  depends_on "llvm"
+  depends_on "numpy"
+  depends_on "qt@5"
+
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+
+  def install
+    ENV["LLVM_INSTALL_DIR"] = Formula["llvm"].opt_prefix
+
+    mkdir "build" do
+      args = std_cmake_args
+      args << "-DCMAKE_PREFIX_PATH=#{Formula["qt@5"].opt_lib}"
+      pyhome = `#{Formula["python@3.10"].opt_bin}/python3.10-config --prefix`.chomp
+      # Building the tests, is effectively a test of Shiboken
+      args << "-DPYTHON_EXECUTABLE=#{pyhome}/bin/python3"
+      args << "-DFORCE_LIMITED_API=yes"
+      args << "-DCMAKE_INSTALL_RPATH=#{lib}"
+
+      system "cmake", *args, "../sources/shiboken2"
+      system "make", "-j#{ENV.make_jobs}", "install"
+    end
+  end
+
+  def caveats
+    <<-EOS
+    this formula is keg-only, and is tied to the version of python
+    that is used to build qt@5, ie. if qt@5 uses python@3.10 then
+    this formula must use python@3.10
+    EOS
+  end
+
+  test do
+    # NOTE: using `#{bin}` allows for testing formula installed in custom prefix
+    system "#{bin}/shiboken2", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
