### PR TITLE
attempt to fix shiboken2 install using brew

### DIFF
--- a/Formula/shiboken2@5.15.5.rb
+++ b/Formula/shiboken2@5.15.5.rb
@@ -43,12 +43,18 @@ class Shiboken2AT5155 < Formula
   def install
     ENV["LLVM_INSTALL_DIR"] = Formula["llvm"].opt_prefix
 
+    pyhome = `#{Formula["python@3.10"].opt_bin}/python3.10-config --prefix`.chomp
+    py_library = "#{pyhome}/lib/libpython3.10.dylib"
+    py_include = "#{pyhome}/include/python3.10"
+
     mkdir "macbuild.#{version}" do
       args = std_cmake_args
       args << "-DCMAKE_PREFIX_PATH=#{Formula["qt@5"].opt_lib}"
-      pyhome = `#{Formula["python@3.10"].opt_bin}/python3.10-config --prefix`.chomp
       # Building the tests, is effectively a test of Shiboken
-      args << "-DPYTHON_EXECUTABLE=#{pyhome}/bin/python3"
+      args << "-DPYTHON_EXECUTABLE=#{pyhome}/bin/python3.10"
+      args << "-DPYTHON_INCLUDE_DIR=#{py_include}"
+      args << "-DPYTHON_LIBRARY=#{py_library}"
+
       args << "-DCMAKE_INSTALL_RPATH=#{lib}"
 
       system "cmake", *args, "../sources/shiboken2"


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
