### PR TITLE
[no ci] exp with using github hosted macos-12 runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,13 @@ jobs:
         # os: [ubuntu-latest, macos-latest] # NOTE: default
         # NOTE: homebrew/homebrew-core uses private self hosted runners
         # NOTE: `macOS-latest` is the default runner provided by github
-        os: [ self-hosted-catalinavm, self-hosted-bigsurvm, self-hosted-mojavevm ]
-        # os: [ self-hosted-catalinavm, self-hosted-bigsurvm ]
-        # os: [ self-hosted-mojavevm ]
+        os: 
+          - self-hosted-catalinavm
+          - self-hosted-bigsurvm
+          - self-hosted-mojavevm
+          - macos-12
+          # os: [ self-hosted-catalinavm, self-hosted-bigsurvm ]
+          # os: [ self-hosted-mojavevm ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
