### PR TITLE
[no ci] attempt to fix style error, make rubocop happy pyside2@5.15.5

### DIFF
--- a/Formula/pyside2@5.15.5.rb
+++ b/Formula/pyside2@5.15.5.rb
@@ -12,9 +12,11 @@ class Pyside2AT5155 < Formula
   end
 
   bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    rebuild 1 if MacOS.version == :mojave
-    sha256 cellar: :any, mojave: "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"
+    on_mojave do
+      root_url "https://ghcr.io/v2/freecad/freecad"
+      rebuild 1
+      sha256 cellar: :any, mojave: "9443f171ff4cb7a48b9ca5280babd1af7abd23e69c418bacae3e236128edd37c"
+    end
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
