### PR TITLE
[no ci] use `--keep-old` with test-bot to allow single bottle updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         run: echo "last_run_status=default" >> $GITHUB_ENV
 
       - name: Restore last run status
-        id: resetore_last_run_status
+        id: restore_last_run_status
         uses: actions/cache@v3.2.2
         with:
           path: |
@@ -133,13 +133,17 @@ jobs:
           # Check if the runner name is vmmojave or vmcatalina and add the flag if true
           if [[ runner.name == 'vmmojave' || runner.name == 'vmcatalina' ]]; then
             brew test-bot \
-              --only-formulae \
-              --only-json-tab \
-              --skip-recursive-dependents \
-              --build-dependents-from-source \
-              --root-url=https://ghcr.io/v2/freecad/homebrew-freecad
+            --skip-online-checks \
+            --keep-old
+            --only-formulae \
+            --only-json-tab \
+            --skip-recursive-dependents \
+            --build-dependents-from-source \
+            --root-url=https://ghcr.io/v2/freecad/homebrew-freecad
           else
             brew test-bot \
+            --skip-online-checks \
+            --keep-old
             --only-formulae \
             --only-json-tab \
             --skip-recursive-dependents \


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
