### PR TITLE
add note about using  [no ci]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,9 @@ jobs:
           if [[ runner.name == 'vmmojave' || runner.name == 'vmcatalina' ]]; then
             brew test-bot \
             --skip-online-checks \
-            --keep-old \
+            # NOTE: ipatch, keep-old is not the droid you're looking for,
+            # see: https://github.com/orgs/Homebrew/discussions/4935
+            # --keep-old \
             --only-formulae \
             --only-json-tab \
             --skip-recursive-dependents \
@@ -143,7 +145,7 @@ jobs:
           else
             brew test-bot \
             --skip-online-checks \
-            --keep-old \
+            # --keep-old \
             --only-formulae \
             --only-json-tab \
             --skip-recursive-dependents \


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
