### PR TITLE
[no ci] elmer remove bottle block use std vtk

### DIFF
--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -18,12 +18,6 @@ class Elmer < Formula
     end
   end
 
-  bottle do
-    root_url "https://github.com/FreeCAD/homebrew-freecad/releases/download/elmer-10pre"
-    rebuild 1
-    sha256 catalina: "85e52e9fbd8078af2fdd846cbc3e7057e626703ee29cc6ab159efbe8d671e801"
-  end
-
   depends_on "cmake" => :build
   depends_on "gcc" => :build
   depends_on "freecad/freecad/opencascade@7.5.3"
@@ -32,7 +26,7 @@ class Elmer < Formula
   depends_on "openblas"
   depends_on "python@3.9"
   depends_on "qt@5"
-  depends_on "vtk@8.2" # no access to sierra test box
+  depends_on "vtk" # no access to sierra test box
   depends_on "webp"
   depends_on "xerces-c"
 


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
