### PR TITLE
qwtelmer [no ci] remove old bottle artifacts

### DIFF
--- a/Formula/qwtelmer.rb
+++ b/Formula/qwtelmer.rb
@@ -4,14 +4,6 @@ class Qwtelmer < Formula
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.6/qwt-6.1.6.tar.bz2"
   sha256 "99460d31c115ee4117b0175d885f47c2c590d784206f09815dc058fbe5ede1f6"
   license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
-  revision 1
-
-  bottle do
-    root_url "https://github.com/FreeCAD/homebrew-freecad/releases/download/qwtelmer-6.1.6_1"
-    rebuild 1
-    sha256 big_sur:  "0cd96db7502718b30c6a66ac1c4fab0daac0fab75488ea3f13ec5db9d484b20e"
-    sha256 catalina: "e7dd5ff1a9f0bdd97fc14f00435b9e0ee8e958b1121f160709dc2fce491a58b2"
-  end
 
   depends_on "qt@5"
 


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
