### PR TITLE
shiboken2 py310 update .pth file location

### DIFF
--- a/Formula/shiboken2@5.15.11_py310.rb
+++ b/Formula/shiboken2@5.15.11_py310.rb
@@ -2,7 +2,7 @@ class Shiboken2AT51511Py310 < Formula
   desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
   homepage "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/README.shiboken2-generator.md?h=5.15.2"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
-  revision 4
+  revision 5
   head "https://github.com/qt/qt5.git", branch: "dev", shallow: false
 
   stable do
@@ -70,12 +70,12 @@ class Shiboken2AT51511Py310 < Formula
     python_version = "3.10"
 
     # Unlink the existing .pth file to avoid reinstall issues
-    pth_file = lib/"python#{python_version}/site-packages/shiboken2.pth"
+    pth_file = lib/"python#{python_version}/shiboken2.pth"
     pth_file.unlink if pth_file.exist?
 
     ohai "Creating .pth file for shiboken2 module"
     # write the .pth file to the site-packages directory
-    (lib/"python#{python_version}/site-packages/shiboken2.pth").write <<~EOS
+    (lib/"python#{python_version}/shiboken2.pth").write <<~EOS
       import site; site.addsitedir('#{lib}/python#{python_version}/site-packages/')
     EOS
   end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
