### PR TITLE
[no ci] fix for homebrew find python.h regardless of linked python in cellar …

### DIFF
--- a/patches/med-file-4.1.1-cmake-find-python-h.patch
+++ b/patches/med-file-4.1.1-cmake-find-python-h.patch
@@ -1,0 +1,25 @@
+commit e25559e46432769b34d8f7ccba466612658e9ef3
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Mon Mar 4 12:37:39 2024 -0600
+
+    fix for homebrew find python.h regardless of linked python in cellar
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9eceab7..583d929 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -113,8 +113,12 @@ MED_FIND_MPI()
+ IF(MEDFILE_BUILD_PYTHON)
+   FIND_PACKAGE(SWIG REQUIRED)
+   INCLUDE(${SWIG_USE_FILE})
+-  FIND_PACKAGE(PythonLibs REQUIRED)
+-  FIND_PACKAGE(PythonInterp REQUIRED)  # to get version string ...
++  IF(HOMEBREW_PREFIX)
++    find_program(PYTHON_EXECUTABLE python HINTS ${Python_ROOT_DIR} PATH_SUFFIXES bin NO_CMAKE_SYSTEM_PATH)
++  ELSE()
++    FIND_PACKAGE(PythonLibs REQUIRED)
++    FIND_PACKAGE(PythonInterp REQUIRED)  # to get version string ...
++  ENDIF()
+ ENDIF()
+ 
+ ## Creation of files med_config.h.cmake


### PR DESCRIPTION
…add patch file [no ci]

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
