### PR TITLE
[no ci] update available runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   test-bot:
     strategy:
-      # NOTE: ipatch, `fail-fast` disabled or subsequent runners / OSes can not run job if previous OS failed
+      # NOTE: ipatch, `fail-fast` disabled because subsequent runners can not run job if previous job failed
       fail-fast: false
       # NOTE: ipatch, all three self hosted runners (vms) are hosted on same computer
       #   ...so limit job to one runner at a time.
@@ -32,13 +32,15 @@ jobs:
         # NOTE: homebrew/homebrew-core uses private self hosted runners
         os: 
           # NOTE: macos-*-large runner requires additional spending limits
-          # - macos-13-large
+          - macos-14-large
+          - macos-14
+          - macos-13-large
           - macos-13
-          # - macos-12-large
+          - macos-12-large
           - macos-12
-          - self-hosted-catalinavm
-          - self-hosted-bigsurvm
-          - self-hosted-mojavevm
+          # - self-hosted-catalinavm
+          # - self-hosted-bigsurvm
+          # - self-hosted-mojavevm
 
     runs-on: ${{ matrix.os }}
 
@@ -50,8 +52,8 @@ jobs:
         id: get_current_date
         run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
-      - name: Log date
-        id: log_date
+      - name: Print value of date from previous step
+        id: print_date
         run: echo "${{ steps.get_current_date.outputs.date }}"
 
       - name: Set default run status
@@ -90,7 +92,7 @@ jobs:
         id: print_env
         run: env
 
-      # NOTE: exp with using a condition to add env var for mojave runner
+      # NOTE: use a condition to add env var for mojave runner
       # REF: https://docs.github.com/en/actions/learn-github-actions/environment-variables
       - name: condition, check runner name 
         if: runner.name == 'vmmojave'


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
