### PR TITLE
[no ci] disable macos-large runners & fix style exceptions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,11 @@ jobs:
         # NOTE: homebrew/homebrew-core uses private self hosted runners
         os: 
           # NOTE: macos-*-large runner requires additional spending limits
-          - macos-14-large
+          # - macos-14-large
           - macos-14
-          - macos-13-large
+          # - macos-13-large
           - macos-13
-          - macos-12-large
+          # - macos-12-large
           - macos-12
           # - self-hosted-catalinavm
           # - self-hosted-bigsurvm

--- a/Formula/elmer.rb
+++ b/Formula/elmer.rb
@@ -1,17 +1,13 @@
 class Elmer < Formula
   desc "CFD"
   homepage "https://www.csc.fi/web/elmer"
-  version "10pre"
   license "GPL-2.0-only" # needs updating
   head "https://github.com/ElmerCSC/elmerfem.git", branch: "devel", shallow: false
 
   stable do
-    url "https://github.com/ElmerCSC/elmerfem.git",
-      revision: "d45484c8fb649ae8fe88bc9752b7e1be1e223f7a"
-    version "v10pre"
-  end
+    url "https://github.com/ElmerCSC/elmerfem.git", revision: "d45484c8fb649ae8fe88bc9752b7e1be1e223f7a", using: :git
+    version "10pre"
 
-  stable do
     patch do
       url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d30bdf481c1e5d52f004b710600eafda3fab44/patches/0001-ipatch-use-gcc-11.patch"
       sha256 "9da090c9a25815bbfea3841087f2b7fff8f7fe015e5e2e10bab6b9a2711b4fd3"

--- a/Formula/freecad@0.20.rb
+++ b/Formula/freecad@0.20.rb
@@ -1,13 +1,11 @@
 class FreecadAT020 < Formula
   desc "Parametric 3D modeler"
   homepage "https://www.freecadweb.org"
+  url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.20.tar.gz"
+  version "0.20"
+  sha256 "c4d9ce782d3da0edfa16d6218db4ce8613e346124ee47b3fe6a6dae40c0a61d9"
   license "GPL-2.0-only"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
-
-  stable do
-    url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.20.tar.gz"
-    sha256 "c4d9ce782d3da0edfa16d6218db4ce8613e346124ee47b3fe6a6dae40c0a61d9"
-  end
 
   option "with-macos-app", "Create FreeCAD.app bundle"
   option "with-cloud", "Build with CLOUD module"

--- a/Formula/opencascade@7.5.3.rb
+++ b/Formula/opencascade@7.5.3.rb
@@ -17,7 +17,7 @@ class OpencascadeAT753 < Formula
     url "https://git.dev.opencascade.org/repos/occt.git"
     regex(/^v?(\d+(?:[._]\d+)+(?:p\d+)?)$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.tr("_", ".") }
     end
   end
 

--- a/Formula/shiboken2@5.15.11.rb
+++ b/Formula/shiboken2@5.15.11.rb
@@ -1,14 +1,11 @@
 class Shiboken2AT51511 < Formula
   desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
   homepage "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/README.shiboken2-generator.md?h=5.15.2"
+  url "https://download.qt.io/official_releases/QtForPython/shiboken2/PySide2-5.15.11-src/pyside-setup-opensource-src-5.15.11.zip"
+  sha256 "9bf6d4f3192697b8d5d7e92219c8d964dcfbfe96a438916bb1cdb78265584081"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
   revision 4
   head "https://github.com/qt/qt5.git", branch: "dev", shallow: false
-
-  stable do
-    url "https://download.qt.io/official_releases/QtForPython/shiboken2/PySide2-5.15.11-src/pyside-setup-opensource-src-5.15.11.zip"
-    sha256 "9bf6d4f3192697b8d5d7e92219c8d964dcfbfe96a438916bb1cdb78265584081"
-  end
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"

--- a/Formula/shiboken2@5.15.11_py310.rb
+++ b/Formula/shiboken2@5.15.11_py310.rb
@@ -1,14 +1,11 @@
 class Shiboken2AT51511Py310 < Formula
   desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
   homepage "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/README.shiboken2-generator.md?h=5.15.2"
+  url "https://download.qt.io/official_releases/QtForPython/shiboken2/PySide2-5.15.11-src/pyside-setup-opensource-src-5.15.11.zip"
+  sha256 "9bf6d4f3192697b8d5d7e92219c8d964dcfbfe96a438916bb1cdb78265584081"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
   revision 5
   head "https://github.com/qt/qt5.git", branch: "dev", shallow: false
-
-  stable do
-    url "https://download.qt.io/official_releases/QtForPython/shiboken2/PySide2-5.15.11-src/pyside-setup-opensource-src-5.15.11.zip"
-    sha256 "9bf6d4f3192697b8d5d7e92219c8d964dcfbfe96a438916bb1cdb78265584081"
-  end
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"

--- a/Formula/shiboken2@5.15.5.rb
+++ b/Formula/shiboken2@5.15.5.rb
@@ -1,14 +1,11 @@
 class Shiboken2AT5155 < Formula
   desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
   homepage "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/README.shiboken2-generator.md?h=5.15.2"
+  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.5-src/pyside-setup-opensource-src-5.15.5.zip"
+  sha256 "d1c61308c53636823c1d0662f410966e4a57c2681b551003e458b2cc65902c41"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
   revision 1
   head "https://github.com/qt/qt5.git", branch: "dev", shallow: false
-
-  stable do
-    url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.5-src/pyside-setup-opensource-src-5.15.5.zip"
-    sha256 "d1c61308c53636823c1d0662f410966e4a57c2681b551003e458b2cc65902c41"
-  end
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
