### PR TITLE
add versioned numpy to py module path

### DIFF
--- a/Formula/fc_bundle.rb
+++ b/Formula/fc_bundle.rb
@@ -16,6 +16,7 @@ class FcBundle < Formula
   end
 
   depends_on "freecad/freecad/coin3d_py310"
+  depends_on "freecad/freecad/numpy@1.26.4_py310"
   depends_on "freecad/freecad/pyside2@5.15.11_py310"
   depends_on "freecad/freecad/shiboken2@5.15.11_py310"
 
@@ -32,11 +33,15 @@ class FcBundle < Formula
     coin3d_pivy_pth_contents =
       File.read("#{Formula["coin3d_py310"].opt_prefix}/lib/python#{pyver}/coin3d_py310-pivy.pth").strip
 
+    numpy_pth_contents =
+      File.read("#{Formula["numpy@1.26.4_py310"].opt_prefix}/lib/python#{pyver}/numpy.pth").strip
+
     site_packages = Language::Python.site_packages("python3.10")
     # {shiboken2_pth_contents}
     pth_contents = <<~EOS
       #{pyside2_pth_contents}
       #{coin3d_pivy_pth_contents}
+      #{numpy_pth_contents}
     EOS
     (prefix/site_packages/"freecad-py-modules.pth").write pth_contents
   end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
