### PR TITLE
freecad@0.20.2_py310: import ocaf2 patch file [no ci]

### DIFF
--- a/patches/freecad-0.20.2-import-ocaf2cpp.patch
+++ b/patches/freecad-0.20.2-import-ocaf2cpp.patch
@@ -1,0 +1,22 @@
+commit 2f146b6a73952b2d59458a99b1e7a882aa7e5c6d
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Thu Apr 25 11:16:09 2024 -0500
+
+    homebrew-freecad attempt to resolve build error, importocaf2.cpp
+
+diff --git a/src/Mod/Import/App/ImportOCAF2.cpp b/src/Mod/Import/App/ImportOCAF2.cpp
+index 8247f080e5..316a88bdba 100644
+--- a/src/Mod/Import/App/ImportOCAF2.cpp
++++ b/src/Mod/Import/App/ImportOCAF2.cpp
+@@ -72,6 +72,11 @@
+ #include <App/DocumentObject.h>
+ #include <App/DocumentObjectGroup.h>
+ 
++// NOTE: ipatch, attempt to resolve the below build err on macos 12.x, aka. monetery
++// err: https://github.com/FreeCAD/homebrew-freecad/actions/runs/8821163910/job/24216438883#step:17:14295
++// ref: https://stackoverflow.com/a/42846010/708807
++#include <array>
++
+ #if OCC_VERSION_HEX >= 0x070500
+ // See https://dev.opencascade.org/content/occt-3d-viewer-becomes-srgb-aware
+ #   define OCC_COLOR_SPACE Quantity_TOC_sRGB


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>

new patch file for `freecad@0.20.2_py310` to resolve build error on macos 12 (monterey) 🫰

```
2024-04-24T20:12:01.0078660Z cd /tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/build/src/Mod/Fem/App && /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_DATE_TIME_DYN_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PP_VARIADICS=1 -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFC_USE_VTK -DFem_EXPORTS -DGL_SILENCE_DEPRECATION -DH5_BUILT_AS_DYNAMIC_LIB -DHAVE_CONFIG_H -DHAVE_LIMITS_H -DQT_CORE_LIB -DQT_NO_DEBUG -DQT_XML_LIB -D_OCC64 -Dkiss_fft_scalar=double -I/tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/build/src/Mod/Fem/App/Fem_autogen/include -I/tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/build -I/usr/local/opt/xerces-c/include -I/tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/build/src -I/tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/FreeCAD-0.20.2/src -I/tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/build/src/Mod/Fem/App -I/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/include/python3.10 -I/tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/FreeCAD-0.20.2/src/3rdParty/salomesmesh/inc -isystem /usr/local/Cellar/boost/1.84.0_1/include -isystem /usr/local/opt/opencascade/include/opencascade -iframework /usr/local/opt/qt@5/lib -isystem /usr/local/opt/qt@5/lib/QtCore.framework/Headers -isystem /usr/local/opt/qt@5/./mkspecs/macx-clang -isystem /usr/local/opt/qt@5/lib/QtXml.framework/Headers -isystem /usr/local/opt/vtk/include/vtk-9.3 -isystem /usr/local/opt/hdf5/include -isystem /usr/local/opt/vtk/include/vtk-9.3/vtkfreetype/include -isystem /usr/local/opt/glew/include -Wall -Wextra -Wpedantic -Wno-write-strings  -Wno-undefined-var-template -Wno-overloaded-virtual -O2 -g -DNDEBUG -std=gnu++17 -isysroot /Applications/Xcode_14.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -mmacosx-version-min=12.7 -fPIC -Wno-pedantic -Wno-inconsistent-missing-override -fPIC -MD -MT src/Mod/Fem/App/CMakeFiles/Fem.dir/FemResultObject.cpp.o -MF CMakeFiles/Fem.dir/FemResultObject.cpp.o.d -o CMakeFiles/Fem.dir/FemResultObject.cpp.o -c /tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/FreeCAD-0.20.2/src/Mod/Fem/App/FemResultObject.cpp
2024-04-24T20:12:01.0099550Z /tmp/freecadA0.20.2_py310-20240424-18836-2byz4v/FreeCAD-0.20.2/src/Mod/Import/App/ImportOCAF2.cpp:1020:39: error: implicit instantiation of undefined template 'std::array<const char *, 3>'
2024-04-24T20:12:01.0101570Z     static std::array<const char *,3> keys = {"Face*","Edge*",marker.c_str()};
2024-04-24T20:12:01.0102340Z                                       ^
2024-04-24T20:12:01.0103490Z /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__tuple:219:64: note: template is declared here
2024-04-24T20:12:01.0104910Z template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
2024-04-24T20:12:01.0105670Z                                                                ^
2024-04-24T20:12:01.0106200Z 1 error generated.
2024-04-24T20:12:01.0106880Z make[2]: *** [src/Mod/Import/App/CMakeFiles/Import.dir/ImportOCAF2.cpp.o] Error 1
2024-04-24T20:12:01.0107870Z make[1]: *** [src/Mod/Import/App/CMakeFiles/Import.dir/all] Error 2
2024-04-24T20:12:01.0108610Z make[1]: *** Waiting for unfinished jobs....
```
