### PR TITLE
freecad@0.20.2_py310: SoFCSelection patch file [no ci]

### DIFF
--- a/patches/freecad-0.20.2-sofcselectioncpp.patch
+++ b/patches/freecad-0.20.2-sofcselectioncpp.patch
@@ -1,0 +1,20 @@
+commit b2b84c02c10ab3ea2db1d540f5ea55ca5857d4b7
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Sat Apr 27 13:29:07 2024 -0500
+
+    homebrew-freecad attempt to resolve build error, SoFCSelection.cpp
+
+diff --git a/src/Gui/SoFCSelection.cpp b/src/Gui/SoFCSelection.cpp
+index a6c819a688..651425cbae 100644
+--- a/src/Gui/SoFCSelection.cpp
++++ b/src/Gui/SoFCSelection.cpp
+@@ -46,6 +46,9 @@
+ #include "SoFCUnifiedSelection.h"
+ #include "ViewParams.h"
+ 
++/// NOTE: ipatch, attempt to resolve the below build err on macos 12.x, aka. monetery
++// ref: https://stackoverflow.com/a/42846010/708807
++#include <array>
+ 
+ // For 64-bit system the method using the front buffer doesn't work at all for lines.
+ // Thus, use the method which forces a redraw every time. This is a bit slower but at


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
