### PR TITLE
pybind11 style error [no ci]

### DIFF
--- a/Formula/pybind11_py310.rb
+++ b/Formula/pybind11_py310.rb
@@ -24,8 +24,8 @@ class Pybind11Py310 < Formula
   depends_on "cmake" => :build
   depends_on "python@3.10" => [:build, :test]
 
-  on_macos do
-    depends_on "gettext" if MacOS.version == :mojave
+  on_mojave :or_older do
+    depends_on "gettext"
   end
 
   def python3


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
