### PR TITLE
swig rebottle, and fix test for gnu+linux

### DIFF
--- a/Formula/swig@4.1.1.rb
+++ b/Formula/swig@4.1.1.rb
@@ -5,7 +5,7 @@ class SwigAT411 < Formula
   url "https://downloads.sourceforge.net/project/swig/swig/swig-4.1.1/swig-4.1.1.tar.gz"
   sha256 "2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b"
   license "GPL-3.0-only"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable
@@ -28,6 +28,7 @@ class SwigAT411 < Formula
 
   keg_only :versioned_formula
 
+  depends_on "ruby" => :test if OS.linux?
   depends_on "pcre2"
 
   uses_from_macos "ruby" => :test
@@ -47,8 +48,7 @@ class SwigAT411 < Formula
     EOS
   end
 
-  # NOTE: add upstream python test this formula, #3
-
+  # NOTE: add upstream python test to this formula
   test do
     (testpath/"test.c").write <<~EOS
       int add(int x, int y)
@@ -67,9 +67,22 @@ class SwigAT411 < Formula
       puts Test.add(1, 1)
     EOS
     system "#{bin}/swig", "-ruby", "test.i"
-    system ENV.cc, "-c", "test.c"
-    system ENV.cc, "-c", "test_wrap.c", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
-    system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
-    assert_equal "2", shell_output("/usr/bin/ruby run.rb").strip
+    if OS.mac?
+      system ENV.cc, "-c", "test.c"
+      system ENV.cc, "-c", "test_wrap.c", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
+      system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
+    else
+      ruby = Formula["ruby"]
+      args = Utils.safe_popen_read(
+        ruby.opt_bin/"ruby", "-e", "'puts RbConfig::CONFIG[\"LIBRUBYARG\"]'"
+      ).chomp
+      system ENV.cc, "-c", "-fPIC", "test.c"
+      system ENV.cc, "-c", "-fPIC", "test_wrap.c",
+        "-I#{ruby.opt_include}/ruby-#{ruby.version.major_minor}.0",
+        "-I#{ruby.opt_include}/ruby-#{ruby.version.major_minor}.0/x86_64-linux/"
+      system ENV.cc, "-shared", "test.o", "test_wrap.o", "-o", "test.so",
+        *args.delete("'").split
+    end
+    assert_equal "2", shell_output("ruby run.rb").strip
   end
 end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
