### PR TITLE
Ci GitHub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,6 +155,10 @@ jobs:
           fi
         if: github.event_name == 'pull_request'
 
+      - name: debug with tmate on failure
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3      
+
       - name: Upload bottles as artifact
         id: upload_bottle_artifacts
         if: always() && github.event_name == 'pull_request'
@@ -168,6 +172,4 @@ jobs:
         if: steps.last_run_status.outputs.last_run_status != 'success'
         run: echo "last_run_status=${{ steps.test_run.outcome }}" >> $GITHUB_ENV
 
-      - name: debug with tmate on failure
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
