### PR TITLE
pybind11 v2.11: rebottle for linux

### DIFF
--- a/Formula/pybind11_py310.rb
+++ b/Formula/pybind11_py310.rb
@@ -11,14 +11,6 @@ class Pybind11Py310 < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "1cddede18121f7c50e8e0e5cdd17ce280f94c63faafa0712ee1a8ae866d595cc"
-    sha256 cellar: :any_skip_relocation, ventura:      "1b56d2b6327e9c96ccdf1707d2340da991617c244aa16be0839477f31588ea43"
-    sha256 cellar: :any_skip_relocation, monterey:     "1b56d2b6327e9c96ccdf1707d2340da991617c244aa16be0839477f31588ea43"
-  end
-
   keg_only :versioned_formula
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
