### PR TITLE
[no ci] update tests.yml and publish.yml workflows for github ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
     runs-on: ubuntu-latest
-    # NOTE: ipatch, don't macos runner to publish bottles
+    # NOTE: ipatch, don't use macos runner to publish bottles
     # SEE: https://github.com/orgs/Homebrew/discussions/4938#discussioncomment-7721218
     # runs-on: [ macos-latest ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Restore last run status
         id: restore_last_run_status
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@v4.0.2
         with:
           path: |
             last_run_status
@@ -83,7 +83,7 @@ jobs:
       - name: Cache Homebrew Bundler RubyGems
         if: steps.last_run_status.outputs.last_run_status != 'success'
         id: cache
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@v4.0.2
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -127,11 +127,15 @@ jobs:
             -e '/go@1.12/d' \
             $(brew --repo homebrew/core)/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
 
+      # NOTE: ipatch, env var required, see, https://github.com/orgs/Homebrew/discussions/4856
+      - name: unset HOMEBREW_NO_INSTALL_FROM_API for linux runners
+        run: |
+          if [[ $RUNNER_OS == 'Linux' ]]; then
+            unset HOMEBREW_NO_INSTALL_FROM_API
+          fi
+
       - name: build bottle using test-bot for current formula
         id: build_bottle
-        # NOTE: ipatch, below env var required, see, https://github.com/orgs/Homebrew/discussions/4856
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
           # Check if the runner name is vmmojave or vmcatalina and add the flag if true
           # NOTE: ipatch, keep-old is not the droid you're looking for,
@@ -173,7 +177,7 @@ jobs:
       - name: Upload bottles as artifact
         id: upload_bottle_artifacts
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
