### PR TITLE
rebuild formula for linux and use python3 var instead of hard coded name

### DIFF
--- a/Formula/coin3d_py310.rb
+++ b/Formula/coin3d_py310.rb
@@ -35,7 +35,6 @@ class Coin3dPy310 < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "freecad/freecad/swig@4.1.1" => :build
-  depends_on "ninja" => :build
   depends_on "boost"
   depends_on "freecad/freecad/pyside2@5.15.11_py310"
   depends_on "python@3.10"
@@ -51,12 +50,11 @@ class Coin3dPy310 < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "_build",
-                    "-DCOIN_BUILD_MAC_FRAMEWORK=OFF",
-                    "-DCOIN_BUILD_DOCUMENTATION=ON",
-                    "-DCOIN_BUILD_TESTS=OFF",
                     "-DCMAKE_CXX_STANDARD=11",
-                    "-L",
-                    *std_cmake_args
+                    "-DCOIN_BUILD_DOCUMENTATION=ON",
+                    "-DCOIN_BUILD_DOCUMENTATION_MAN=ON",
+                    "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+                    "-L"
     system "cmake", "--build", "_build"
     system "cmake", "--install", "_build"
 
@@ -86,7 +84,8 @@ class Coin3dPy310 < Formula
     <<~EOS
       this formula is keg-only, and intended to aid in the building of freecad
       this formula should NOT be linked using `brew link` or else errors will
-      arise when opening the python3.10 repl
+      arise when opening the #{python3} repl
+      the test in this formula will fail in a screen (GUI) can not be accessed
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
