### PR TITLE
freecad@0.21.2_py310: checkin patch file for boost v1.85.0 [no ci]

### DIFF
--- a/patches/freecad@0.21.2_py310-boost-185-PreferencePackManager-cpp.patch
+++ b/patches/freecad@0.21.2_py310-boost-185-PreferencePackManager-cpp.patch
@@ -1,0 +1,22 @@
+commit b0afb188081b41e4588686af91160f80e0b49705
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Fri Jun 7 17:36:12 2024 -0500
+
+    ipatch: fix PreferencePackManger.cpp for boost v1.85.0
+
+diff --git a/src/Gui/PreferencePackManager.cpp b/src/Gui/PreferencePackManager.cpp
+index ed6f75d464..d0098367b5 100644
+--- a/src/Gui/PreferencePackManager.cpp
++++ b/src/Gui/PreferencePackManager.cpp
+@@ -221,7 +221,11 @@ void Gui::PreferencePackManager::importConfig(const std::string& packName,
+     auto savedPreferencePacksDirectory =
+         fs::path(App::Application::getUserAppDataDir()) / "SavedPreferencePacks";
+     auto cfgFilename = savedPreferencePacksDirectory / packName / (packName + ".cfg");
++#if BOOST_VERSION >= 108500
++    fs::copy_file(path, cfgFilename, fs::copy_options::overwrite_existing);
++#else
+     fs::copy_file(path, cfgFilename, fs::copy_option::overwrite_if_exists);
++#endif
+     rescan();
+ }
+ 


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
