### PR TITLE
freecad@0.20.2_py310: add patch file for toposhape.h [no ci]

### DIFF
--- a/patches/freecad@0.21.2_py310-HEAD-toposhape.h-fix.patch
+++ b/patches/freecad@0.21.2_py310-HEAD-toposhape.h-fix.patch
@@ -1,0 +1,19 @@
+commit a48198bca873e2106970a57ef04a80f7df766e47
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Tue Jul 9 18:21:08 2024 -0500
+
+    toposhape.h add missing include
+
+diff --git a/src/Mod/Part/App/TopoShape.h b/src/Mod/Part/App/TopoShape.h
+index cceb920f8e..5a1e6bcb4f 100644
+--- a/src/Mod/Part/App/TopoShape.h
++++ b/src/Mod/Part/App/TopoShape.h
+@@ -43,6 +43,8 @@
+ #include <BRepTools_ReShape.hxx>
+ #include <ShapeFix_Root.hxx>
+ 
++#include <unordered_map>
++
+ class gp_Ax1;
+ class gp_Ax2;
+ class gp_Pln;


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
