### PR TITLE
freecad@0.21.2_py310: update formula to build dfe0c5d add patch file …

### DIFF
--- a/patches/freecad@0.21.2_py310-HEAD-pybind11-cmake-setup.patch
+++ b/patches/freecad@0.21.2_py310-HEAD-pybind11-cmake-setup.patch
@@ -1,0 +1,29 @@
+commit f64299b543c80f1758a6e8eadedbc85214c7db41
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Wed Jul 10 10:50:16 2024 -0500
+
+    pybind11 cmake setup patch
+
+diff --git a/cMake/FreeCAD_Helpers/SetupPybind11.cmake b/cMake/FreeCAD_Helpers/SetupPybind11.cmake
+index 7fc65dfe86..79e50c5039 100644
+--- a/cMake/FreeCAD_Helpers/SetupPybind11.cmake
++++ b/cMake/FreeCAD_Helpers/SetupPybind11.cmake
+@@ -4,7 +4,18 @@ macro(SetupPybind11)
+     # necessary for flat-mesh feature
+     option(FREECAD_USE_PYBIND11 "Use pybind11" OFF)
+     if (FREECAD_USE_PYBIND11)
++      if(HOMEBREW_PREFIX)
++        # https://pybind11.readthedocs.io/en/stable/cmake/index.html
++        # Specify the custom path for pybind11
++        set(pybind11_DIR ${HOMEBREW_PREFIX}/opt/pybind11_py310/share/cmake/pybind11)
++        include_directories(${pybind11_INCLUDE_DIRS})
++
++        # Display information about pybind11 found by CMake
++        message(STATUS "pybind11 include directory: ${pybind11_INCLUDE_DIRS}")
++        message(STATUS "pybind11 library: ${pybind11_LIBRARY}")
++      else()
+         find_package(pybind11 REQUIRED)
++      endif()
+     endif()
+ 
+ endmacro(SetupPybind11)


### PR DESCRIPTION
…for pybind11 [no ci]

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
