### PR TITLE
[no ci] freecad@0.20.2_py310: backport occ v7.8 cmake for 0.21.2

### DIFF
--- a/patches/freecad@0.21.2_py310-backport-occ-v7.8.patch
+++ b/patches/freecad@0.21.2_py310-backport-occ-v7.8.patch
@@ -1,0 +1,57 @@
+commit 3af052684c935e9eec1976deacbb904c20eb5e1e
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Sat Jul 13 17:06:40 2024 -0500
+
+    freecad@0.20.2_py310: backport occ v7.8 cmake for 0.21.2
+
+diff --git a/cMake/FindOCC.cmake b/cMake/FindOCC.cmake
+index 48e5c98750..c72066f43e 100644
+--- a/cMake/FindOCC.cmake
++++ b/cMake/FindOCC.cmake
+@@ -127,8 +127,6 @@ if(OCC_FOUND)
+     TKG2d
+     TKG3d
+     TKMath
+-    TKIGES
+-    TKSTL
+     TKShHealing
+     TKXSBase
+     TKBool
+@@ -139,10 +137,6 @@ if(OCC_FOUND)
+     TKGeomBase
+     TKOffset
+     TKPrim
+-    TKSTEPBase
+-    TKSTEPAttr
+-    TKSTEP209
+-    TKSTEP
+     TKHLR
+     TKFeat
+   )
+@@ -154,17 +148,20 @@ if(OCC_FOUND)
+     TKLCAF
+     TKVCAF
+     TKCDF
+-    TKXDESTEP
+-    TKXDEIGES
+     TKMeshVS
+     TKService
+     TKV3d
+   )
+-  if(OCC_VERSION_STRING VERSION_LESS 6.7.3)
+-    list(APPEND OCC_OCAF_LIBRARIES TKAdvTools)
+-  elseif(NOT OCC_VERSION_STRING VERSION_LESS 7.5.0)
++
++  if(NOT OCC_VERSION_STRING VERSION_LESS 7.5.0)
+     list(APPEND OCC_OCAF_LIBRARIES TKRWMesh)
+-  endif(OCC_VERSION_STRING VERSION_LESS 6.7.3)
++  endif(NOT OCC_VERSION_STRING VERSION_LESS 7.5.0)
++  if(OCC_VERSION_STRING VERSION_LESS 7.8.0)
++    list(APPEND OCC_LIBRARIES TKIGES TKSTL TKSTEPBase TKSTEPAttr TKSTEP209 TKSTEP)
++    list(APPEND OCC_OCAF_LIBRARIES TKXDESTEP TKXDEIGES)
++  else(OCC_VERSION_STRING VERSION_LESS 7.8.0)
++    list(APPEND OCC_LIBRARIES TKDESTEP TKDEIGES TKDEGLTF TKDESTL)
++  endif(OCC_VERSION_STRING VERSION_LESS 7.8.0)
+   message(STATUS "-- Found OCE/OpenCASCADE version: ${OCC_VERSION_STRING}")
+   message(STATUS "-- OCE/OpenCASCADE include directory: ${OCC_INCLUDE_DIR}")
+   message(STATUS "-- OCE/OpenCASCADE shared libraries directory: ${OCC_LIBRARY_DIR}")


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
