### PR TITLE
swig: checkin new versioned formula of swig v4.2.1

### DIFF
--- a/Formula/swig@4.2.1.rb
+++ b/Formula/swig@4.2.1.rb
@@ -1,0 +1,79 @@
+class SwigAT421 < Formula
+  desc "Generate scripting interfaces to C/C++ code"
+  homepage "https://www.swig.org/"
+  # NOTE: see github issue, https://github.com/swig/swig/issues/2069
+  url "https://downloads.sourceforge.net/project/swig/swig/swig-4.2.1/swig-4.2.1.tar.gz"
+  sha256 "fa045354e2d048b2cddc69579e4256245d4676894858fcf0bab2290ecf59b7d8"
+  license "GPL-3.0-only"
+
+  livecheck do
+    url :stable
+  end
+
+  head do
+    url "https://github.com/swig/swig.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "ruby" => :test if OS.linux?
+  depends_on "pcre2"
+
+  uses_from_macos "ruby" => :test
+
+  def install
+    system "./autogen.sh" if build.head?
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  def caveats
+    <<-EOS
+    this formula is keg only due to upstream
+    counterpart in homebrew-core
+    EOS
+  end
+
+  # NOTE: add upstream python test to this formula
+  test do
+    (testpath/"test.c").write <<~EOS
+      int add(int x, int y)
+      {
+        return x + y;
+      }
+    EOS
+    (testpath/"test.i").write <<~EOS
+      %module test
+      %inline %{
+      extern int add(int x, int y);
+      %}
+    EOS
+    (testpath/"run.rb").write <<~EOS
+      require "./test"
+      puts Test.add(1, 1)
+    EOS
+    system "#{bin}/swig", "-ruby", "test.i"
+    if OS.mac?
+      system ENV.cc, "-c", "test.c"
+      system ENV.cc, "-c", "test_wrap.c", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Ruby.framework/Headers/"
+      system ENV.cc, "-bundle", "-undefined", "dynamic_lookup", "test.o", "test_wrap.o", "-o", "test.bundle"
+    else
+      ruby = Formula["ruby"]
+      args = Utils.safe_popen_read(
+        ruby.opt_bin/"ruby", "-e", "'puts RbConfig::CONFIG[\"LIBRUBYARG\"]'"
+      ).chomp
+      system ENV.cc, "-c", "-fPIC", "test.c"
+      system ENV.cc, "-c", "-fPIC", "test_wrap.c",
+        "-I#{ruby.opt_include}/ruby-#{ruby.version.major_minor}.0",
+        "-I#{ruby.opt_include}/ruby-#{ruby.version.major_minor}.0/x86_64-linux/"
+      system ENV.cc, "-shared", "test.o", "test_wrap.o", "-o", "test.so",
+        *args.delete("'").split
+    end
+    assert_equal "2", shell_output("ruby run.rb").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
