### PR TITLE
[no ci] update tests.yml to work with latest macos runner image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,19 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest] # NOTE: default
         # NOTE: homebrew/homebrew-core uses private self hosted runners
+        # https://github.com/actions/runner-images
         os: 
-          - ubuntu-22.04
           # NOTE: macos-*-large runner requires additional spending limits
           # - macos-14-large
+          - macos-15
           - macos-14
           # - macos-13-large
+          # NOTE: macos-13 is the last free intel runner provided by github
           - macos-13
           # - macos-12-large
-          - macos-12
+          # upstream homebrew-core has deprecated macos-12 and github will retire images on 12/3/24
+          # - macos-12
+          - ubuntu-22.04
           # - self-hosted-catalinavm
           # - self-hosted-bigsurvm
           # - self-hosted-mojavevm
@@ -197,5 +201,4 @@ jobs:
         id: save-run-status
         if: steps.set-last-run-status.outputs.last-run-status != 'success'
         run: echo "last-run-status=${{ steps.build-bottle.outcome }}" >> "$GITHUB-ENV"
-
 


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
