### PR TITLE
pybind11_py312: revision bump rebuild pybind11_py312

### DIFF
--- a/Formula/pybind11_py312.rb
+++ b/Formula/pybind11_py312.rb
@@ -4,6 +4,7 @@ class Pybind11Py312 < Formula
   url "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz"
   sha256 "e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/pybind/pybind11.git", branch: "master", shallow: false
 
   livecheck do


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
