### PR TITLE
[no ci] checkin in patch file

### DIFF
--- a/patches/freecad@1.0.0_rc2_py312-fix-pyside-path-issue.patch
+++ b/patches/freecad@1.0.0_rc2_py312-fix-pyside-path-issue.patch
@@ -1,0 +1,19 @@
+commit a9681c579d190630aaf979fb4769192b33885f07
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Thu Oct 24 15:25:41 2024 +0000
+
+    freecad@1.0.0_rc2_py312: fix runtime issue with PySide
+
+diff --git a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+index 5626251..550f5e6 100644
+--- a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
++++ b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+@@ -109,7 +109,7 @@ macro(SetupShibokenAndPyside)
+         DIRECTORY
+             ${CMAKE_BINARY_DIR}/Ext/PySide
+         DESTINATION
+-            MacOS
++            Ext
+         )
+     else()
+         install(


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
