### PR TITLE
freecad@0.21.2_py310: tshoot ubuntu build error with ci

### DIFF
--- a/Formula/freecad@0.21.2_py310.rb
+++ b/Formula/freecad@0.21.2_py310.rb
@@ -341,12 +341,22 @@ class FreecadAT0212Py310 < Formula
   def post_install
     if OS.mac?
       ohai "the value of prefix = #{prefix}"
-      ln_s "#{prefix}/MacOS/FreeCAD", "#{HOMEBREW_PREFIX}/bin/freecad", force: true
-      ln_s "#{prefix}/MacOS/FreeCADCmd", "#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
+      freecad_path = Pathname.new("#{prefix}/MacOS/FreeCAD")
+      freecadcmd_path = Pathname.new("#{prefix}/MacOS/FreeCADCmd")
+
+      ln_s freecad_path.relative_path_from(Pathname.new("#{HOMEBREW_PREFIX}/bin")), "#{HOMEBREW_PREFIX}/bin/freecad",
+force: true
+      ln_s freecadcmd_path.relative_path_from(Pathname.new("#{HOMEBREW_PREFIX}/bin")),
+"#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
     elsif OS.linux?
       ohai "the value of prefix = #{prefix}"
-      ln_s "#{bin}/FreeCAD", "#{HOMEBREW_PREFIX}/bin/freecad", force: true
-      ln_s "#{bin}/FreeCADCmd", "#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
+      freecad_path = Pathname.new("#{bin}/FreeCAD")
+      freecadcmd_path = Pathname.new("#{bin}/FreeCADCmd")
+
+      ln_s freecad_path.relative_path_from(Pathname.new("#{HOMEBREW_PREFIX}/bin")), "#{HOMEBREW_PREFIX}/bin/freecad",
+force: true
+      ln_s freecadcmd_path.relative_path_from(Pathname.new("#{HOMEBREW_PREFIX}/bin")),
+"#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
     end
   end
 


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
