### PR TITLE
Hbfc tap maintenance [no ci]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,18 +100,27 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
+      - name: Fetch GitHub runners and check if self-hosted
+        id: fetch-runners-then-check-for-self-hosted
+        run: |
+          RESPONSE=$(curl -s -L \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/freecad/homebrew-freecad/actions/runners)
+                                                                                                                                      # Check if any runner is self-hosted
+          RUNNER_NAME=$(echo "$RESPONSE" | jq -r '.runners[] | select(.labels[]?.name == "self-hosted") | .name')
+
+          if [ -n "$RUNNER_NAME" ]; then
+            echo "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1" >> "$GITHUB_ENV"
+            echo "Self-hosted runner found: $RUNNER_NAME"
+          else
+            echo "No self-hosted runner found"
+          fi
+
       - name: print env
         id: print-env
         run: env
-
-      - name: set GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED env var for self-hosted runners
-        id: set-homebrew-specific-env-var-for-self-hosted-runners
-        run: |
-          if [[ "${{ github.action_status }}" == "self-hosted" ]]; then
-            echo "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1" >> "$GITHUB_ENV"
-          else
-            echo "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=0" >> "$GITHUB_ENV"
-          fi
 
       - name: check env
         id: print-the-value-of-GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED-env-var


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
