### PR TITLE
[no ci] tshooting gh tokens

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,11 +52,12 @@ jobs:
           - self-hosted-ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
-    permissions:
-      actions: write
-      contents: write
-      packages: write
-      pull-requests: write
+    permissions: read-all
+    # permissions:
+    #   actions: write
+    #   contents: write
+    #   packages: write
+    #   pull-requests: write
 
     timeout-minutes: 1200
 
@@ -70,11 +71,11 @@ jobs:
           #   exit 1
           # fi
 
-          # -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}" \
           # https://api.github.com/repos/${{ github.repository }})
           #
           RESPONSE=$(curl -v -s -L \
-          -H "Authorization: Bearer ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/freecad/homebrew-freecad/actions/runners)


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
