### PR TITLE
[no ci] exp with using pull_request_target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
       - master
 
   pull_request:
+  pull_request_target:
 
   workflow_dispatch:  # NOTE: nova with homebrew gha
 
@@ -62,33 +63,33 @@ jobs:
     timeout-minutes: 1200
 
     steps:
-      # https://stackoverflow.com/a/77882553/708807
-      - name: Generate github app token
-        id: generate-gh-app-token
-        uses: actions/create-github-app-token@v1.11.0
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      # # https://stackoverflow.com/a/77882553/708807
+      # - name: Generate github app token
+      #   id: generate-gh-app-token
+      #   uses: actions/create-github-app-token@v1.11.0
+      #   with:
+      #     app-id: ${{ vars.APP_ID }}
+      #     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Use the token
-        env:
-          GH_TOKEN: ${{ steps.generate-gh-app-token.outputs.token }}
-        run: |
-          # gh api octocat
-          RESPONSE=$(curl -v -s -L \
-          -H "Authorization: Bearer $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/freecad/homebrew-freecad/actions/runners)
+      # - name: Use the token
+      #   # env:
+      #   #   GH_TOKEN: ${{ steps.generate-gh-app-token.outputs.token }}
+      #   run: |
+      #     # gh api octocat
+      #     RESPONSE=$(curl -v -s -L \
+      #     -H "Authorization: Bearer $GITHUB_TOKEN" \
+      #     -H "Accept: application/vnd.github+json" \
+      #     -H "X-GitHub-Api-Version: 2022-11-28" \
+      #     https://api.github.com/repos/freecad/homebrew-freecad/actions/runners)
 
-          echo "API response: $RESPONSE"
+      #     echo "API response: $RESPONSE"
 
-          if echo "$RESPONSE" | grep -q '"message": "Bad credentials"'; then
-            echo "Error: Bad credentials - the GitHub token may be invalid or lacks permissions."
-            exit 1
-          fi
+      #     if echo "$RESPONSE" | grep -q '"message": "Bad credentials"'; then
+      #       echo "Error: Bad credentials - the GitHub token may be invalid or lacks permissions."
+      #       exit 1
+      #     fi
 
-          echo "Success: GitHub token is valid."
+      #     echo "Success: GitHub token is valid."
 
       - name: Test GitHub Token
         # env:
@@ -98,12 +99,12 @@ jobs:
           #   echo "Error: GITHUB_TOKEN is not set."
           #   exit 1
           # fi
+          # -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
 
-          # -H "Authorization: Bearer ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}" \
           # https://api.github.com/repos/${{ github.repository }})
           #
           RESPONSE=$(curl -v -s -L \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/freecad/homebrew-freecad/actions/runners)


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
