### PR TITLE
[no ci] let certain steps continue to run even if they fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,8 @@ jobs:
 
       #     echo "Success: GitHub token is valid."
 
-      - name: Test GitHub Token
+      - name: Test GitHub Token, ie. HOMEBREW_GITHUB_API_TOKEN
+        continue-on-error: true
         run: |
           RESPONSE=$(curl -s -L \
           -H "Authorization: Bearer ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}" \
@@ -152,6 +153,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Fetch GitHub runners and check if self-hosted
+        continue-on-error: true
         id: fetch-runners-then-check-for-self-hosted
         run: |
           RESPONSE=$(curl -s -L \
@@ -228,8 +230,8 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      # NOTE: ipatch, attempt to set homebrew-core repo to specific commit for catalina bottling
       - name: check for catalina vm and set homebrew-core repo to specific commit
+      # NOTE: ipatch, attempt to set homebrew-core repo to specific commit for catalina bottling
         if: runner.name == 'vmcatalina'
         run: |
           cd "$(brew --repo homebrew/core)"; \
@@ -245,8 +247,8 @@ jobs:
             -e '/go@1.12/d' \
             "$(brew --repo homebrew/core)/style_exceptions/binary_bootstrap_formula_urls_allowlist.json"
 
-      # NOTE: ipatch, env var required, see, https://github.com/orgs/Homebrew/discussions/4856
       - name: unset HOMEBREW_NO_INSTALL_FROM_API for linux runners -------------------
+      # NOTE: ipatch, env var required, see, https://github.com/orgs/Homebrew/discussions/4856
         run: |
           if [[ $RUNNER_OS == 'Linux' ]]; then
             unset HOMEBREW_NO_INSTALL_FROM_API


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
