### PR TITLE
[no ci] manually set env var for GITHUB_ENV based on RUNNER_NAME

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,6 +174,16 @@ jobs:
             echo "No self-hosted runner found"
           fi
 
+      - name: manually update GITHUB_ENV based on RUNNER_NAME
+        id: update-github_env-based-on-runner_name
+        run: |
+          if [ "$RUNNER_NAME" = "self-hosted-ubuntu-22.04" ]; then
+            echo "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1" >> "$GITHUB_ENV"
+            echo "Self-hosted runner found: $RUNNER_NAME"
+          else
+            echo "No self-hosted runner found"
+          fi
+
       # # Step to add Homebrew paths to GITHUB_ENV if using act locally
       # - name: Set Homebrew environment variables for act
       #   if: runner.os == 'Linux' && env.ACT == 'true'


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
