### PR TITLE
[no ci] update tests.yml workflow to use new env vars in attempt to NOT remove installed formula for self-hosted runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,9 @@ jobs:
         run: |
           if [ "$RUNNER_NAME" = "self-hosted-ubuntu-22.04" ]; then
             echo "GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1" >> "$GITHUB_ENV"
-            echo "GITHUB_ACTIONS=0" >> "$GITHUB_ENV"
+            echo "HOMEBREW_GITHUB_ACTIONS=1" >> "$GITHUB_ENV"
+            export GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1
+            export HOMEBREW_GITHUB_ACTIONS=1
             echo "Self-hosted runner found: $RUNNER_NAME"
           else
             echo "No self-hosted runner found"
@@ -312,9 +314,9 @@ jobs:
           # shut down server after 10 minutes if no one connects
           wait-timeout-minutes: 10
 
+      - name: Upload bottles as artifact
       # NOTE: ipatch, issue using upload-artifact@v4 
       # see: https://github.com/actions/upload-artifact/issues/478
-      - name: Upload bottles as artifact
         id: upload-bottle-artifacts
         if: always() && github.event_name == 'pull_request'
         # uses: actions/upload-artifact@v4.3.3


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
