### PR TITLE
tshoot: add condition to only run cleanup before on non self-hosted runner ie. github hosted [no ci]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,11 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true' && steps.set-last-run-status.outputs.last-run-status != 'success'
         run: brew install-bundler-gems
 
-      - run: brew test-bot --only-cleanup-before
+      - name: only run brew test-bot cleanup before on github hosted runners
+        if: ${{ !contains(matrix.os, 'self-hosted-ubuntu-22.04') }}
+        id: brew-test-bot-cleanup-before
+        run: |
+          brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup
 


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
