### PR TITLE
[no ci] checkin a basic .rubocop.yml file for basic linting and new patch for hdf5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,20 @@
+---
+AllCops:
+  TargetRubyVersion: 3.3
+  NewCops: enable
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+Layout/SpaceAroundOperators:
+  Enabled: false
+Style/StringConcatenation:
+  Exclude:
+  - "**/{Formula,Casks}/**/*.rb"
+Style/FetchEnvVar:
+  Exclude:
+  - "**/Formula/**/*.rb"
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+

--- a/patches/freecad@0.21.2_py310-hdf5-cmake-fix.patch
+++ b/patches/freecad@0.21.2_py310-hdf5-cmake-fix.patch
@@ -1,0 +1,20 @@
+commit c0021f32f711e28328e16363f692ba8e41474577
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Tue Nov 12 19:34:53 2024 +0000
+
+    freecad@0.21.2_py310: fix cmake HDF5 error ie. issue #583
+
+diff --git a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+index 513ec18..7744a21 100644
+--- a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
++++ b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+@@ -91,7 +91,8 @@ macro(SetupSalomeSMESH)
+                 endif()
+                 pkg_search_module(HDF5 ${HDF5_VARIANT})
+                 if(HOMEBREW_PREFIX)
+-                  set(HDF5_ROOT ${HOMEBREW_PREFIX}/opt/hdf5)
++                  unset(HDF5_FOUND CACHE)
++                  # set(HDF5_ROOT ${HOMEBREW_PREFIX}/opt/hdf5)
+                   message("--------------------------------------------")
+                   message("ipatch, manually set hdf5_root, cmake build of hdf5 breaks h5cc")
+                   message("--------------------------------------------")


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
