### PR TITLE
[no ci] freecad@0.21.2_py310 checkin new patch for hdf5

### DIFF
--- a/patches/freecad@0.21.2_py310-hdf5-fix-cmake-reruns.patch
+++ b/patches/freecad@0.21.2_py310-hdf5-fix-cmake-reruns.patch
@@ -1,0 +1,52 @@
+commit 7bfead6fe7fcd0dbe7032f28c22d55ffc57f73b1
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Thu Nov 21 15:17:01 2024 -0600
+
+    foo
+
+diff --git a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+index 1a58efa3e5..88389de946 100644
+--- a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
++++ b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+@@ -90,20 +90,28 @@ macro(SetupSalomeSMESH)
+                     set(HDF5_PREFER_PARALLEL TRUE) # if pkg-config fails, find_package(HDF5) needs this
+                 endif()
+                 pkg_search_module(HDF5 ${HDF5_VARIANT})
+-                if(NOT HDF5_FOUND)
+-                    find_package(HDF5 REQUIRED)
++                if(HOMEBREW_PREFIX)
++                  unset(HDF5_FOUND CACHE)
++                  message("--------------------------------------------")
++                  message("ipatch, DO NOT cache HDF5_FOUND cmake build of hdf5 breaks h5cc")
++                  message("see: https://github.com/FreeCAD/homebrew-freecad/issues/583")
++                  message("--------------------------------------------")
+                 else()
+-                    add_compile_options(${HDF5_CFLAGS})
+-                    link_directories(${HDF5_LIBRARY_DIRS})
+-                    link_libraries(${HDF5_LIBRARIES})
+-                    find_file(Hdf5dotH hdf5.h PATHS ${HDF5_INCLUDE_DIRS} NO_DEFAULT_PATH)
+-                    if(NOT Hdf5dotH)
+-                        message( FATAL_ERROR "${HDF5_VARIANT} development header not found.")
+-                    endif()
+-                endif()
+-                check_include_file_cxx(hdf5.h HDF5_FOUND)
+-                if(NOT HDF5_FOUND)
+-                    message( FATAL_ERROR "hdf5.h was not found.")
++                  if(NOT HDF5_FOUND)
++                      find_package(HDF5 REQUIRED CONFIG)
++                  else()
++                      add_compile_options(${HDF5_CFLAGS})
++                      link_directories(${HDF5_LIBRARY_DIRS})
++                      link_libraries(${HDF5_LIBRARIES})
++                      find_file(Hdf5dotH hdf5.h PATHS ${HDF5_INCLUDE_DIRS} NO_DEFAULT_PATH)
++                      if(NOT Hdf5dotH)
++                          message( FATAL_ERROR "${HDF5_VARIANT} development header not found.")
++                      endif()
++                  endif()
++                  check_include_file_cxx(hdf5.h HDF5_FOUND)
++                  if(NOT HDF5_FOUND)
++                      message( FATAL_ERROR "hdf5.h was not found.")
++                  endif()
+                 endif()
+ 
+                 # Med Fichier can require MPI


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
