### PR TITLE
hbfc tap maintenance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Restore last run status
         id: restore-last-run-status
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.2.3
         with:
           path: |
             last-run-status
@@ -118,7 +118,7 @@ jobs:
       - name: Cache Homebrew Bundler RubyGems
         if: steps.set-last-run-status.outputs.last-run-status != 'success'
         id: cache
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -296,7 +296,8 @@ jobs:
         id: upload-bottle-artifacts
         if: always() && github.event_name == 'pull_request'
         # uses: actions/upload-artifact@v4.3.3
-        uses: actions/upload-artifact@v3.1.3
+        # uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
- **hbfc tap maintenance, attempt to resolve issue in pr #675 [no ci]**
- **hbfc tap maintenance, attempt to resolve issue in pr #675 [no ci]**

- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

```
brew style freecad/freecad/[NAME_OF_FORMULA_FILE] 
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
