### PR TITLE
[no ci] checkin new patch file to fix 1.0.1 bld err with occ v7.9

### DIFF
--- a/patches/freecad@1.0.1_py312-fix-bld-with-occ-v79.patch
+++ b/patches/freecad@1.0.1_py312-fix-bld-with-occ-v79.patch
@@ -1,0 +1,21 @@
+From 585e80066adc2ae9300f6706ae971f1cd3ddd0c4 Mon Sep 17 00:00:00 2001
+From: chris <chris.r.jones.1983@gmail.com>
+Date: Sun, 18 May 2025 14:48:12 -0500
+Subject: [PATCH] fix for upstream #20656 to work with 1.0.1 tarball
+
+---
+ cMake/FindOCC.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cMake/FindOCC.cmake b/cMake/FindOCC.cmake
+index c72066f43e2f33f5c35fd3848c7149bb9e341b9c..56d15936349bfcaa77fad1638b50d727a1877da1 100644
+--- a/cMake/FindOCC.cmake
++++ b/cMake/FindOCC.cmake
+@@ -139,6 +139,7 @@ if(OCC_FOUND)
+     TKPrim
+     TKHLR
+     TKFeat
++    TKExpress
+   )
+   set(OCC_OCAF_LIBRARIES
+     TKBin


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
