### PR TITLE
FreeCADWeb.Org ➞ FreeCAD.Org

### DIFF
--- a/Formula/fc_bundle.rb
+++ b/Formula/fc_bundle.rb
@@ -1,6 +1,6 @@
 class FcBundle < Formula
   desc "Meta formula for bundling needed python modules"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   # Dummy URL since no source is being downloaded
   url "file:///dev/null"
   version "0.21.1"

--- a/Formula/fc_bundle_py312.rb
+++ b/Formula/fc_bundle_py312.rb
@@ -1,6 +1,6 @@
 class FcBundlePy312 < Formula
   desc "Meta formula for bundling needed python modules"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   # Dummy URL since no source is being downloaded
   url "file:///dev/null"
   # this version works with the freecad v1rc2 release thus the 0.9.2 versioning

--- a/Formula/fc_bundle_py312_qt6.rb
+++ b/Formula/fc_bundle_py312_qt6.rb
@@ -1,6 +1,6 @@
 class FcBundlePy312Qt6 < Formula
   desc "Meta formula for bundling needed python modules"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   # Dummy URL since no source is being downloaded
   url "file:///dev/null"
   # this version works with the freecad v1rc2 release thus the 0.9.2 versioning

--- a/Formula/freecad@0.20.1.rb
+++ b/Formula/freecad@0.20.1.rb
@@ -1,6 +1,6 @@
 class FreecadAT0201 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   license "GPL-2.0-only"
   head "https://github.com/freecad/FreeCAD.git", branch: "master", shallow: false
 

--- a/Formula/freecad@0.20.2_py310.rb
+++ b/Formula/freecad@0.20.2_py310.rb
@@ -1,6 +1,6 @@
 class FreecadAT0202Py310 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.20.2.tar.gz"
   sha256 "46922f3a477e742e1a89cd5346692d63aebb2b67af887b3e463e094a4ae055da"
   license "GPL-2.0-only"

--- a/Formula/freecad@0.20.rb
+++ b/Formula/freecad@0.20.rb
@@ -1,6 +1,6 @@
 class FreecadAT020 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/0.20.tar.gz"
   sha256 "c4d9ce782d3da0edfa16d6218db4ce8613e346124ee47b3fe6a6dae40c0a61d9"
   license "GPL-2.0-only"

--- a/Formula/freecad@0.21.2_py310.rb
+++ b/Formula/freecad@0.21.2_py310.rb
@@ -1,6 +1,6 @@
 class FreecadAT0212Py310 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
   # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`

--- a/Formula/freecad@1.0.0_py312.rb
+++ b/Formula/freecad@1.0.0_py312.rb
@@ -1,6 +1,6 @@
 class FreecadAT100Py312 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
   # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`

--- a/Formula/freecad@1.0.0_py312_qt6.rb
+++ b/Formula/freecad@1.0.0_py312_qt6.rb
@@ -1,6 +1,6 @@
 class FreecadAT100Py312Qt6 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
   # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`

--- a/Formula/freecad@1.0.1_py312.rb
+++ b/Formula/freecad@1.0.1_py312.rb
@@ -1,6 +1,6 @@
 class FreecadAT101Py312 < Formula
   desc "Parametric 3D modeler"
-  homepage "https://www.freecadweb.org"
+  homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
   # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`

--- a/Formula/opencascade@7.5.3.rb
+++ b/Formula/opencascade@7.5.3.rb
@@ -31,7 +31,7 @@ class OpencascadeAT753 < Formula
   depends_on "tcl-tk"
 
   # NOTE: https://tracker.dev.opencascade.org/view.php?id=32328
-  # NOTE: https://forum.freecadweb.org/viewtopic.php?f=4&t=58090
+  # NOTE: https://forum.freecad.org/viewtopic.php?f=4&t=58090
   patch :DATA
 
   def install

--- a/casks/freecad.rb
+++ b/casks/freecad.rb
@@ -8,7 +8,7 @@ cask "freecad" do
       verified: "github.com/freecad/homebrew-freecad/"
   name "FreeCAD"
   desc "3D parametric modler"
-  homepage "https://www.freecad.org/"
+  homepage "https://freecad.org/"
 
   livecheck do
     url "https://github.com/freecad/homebrew-freecad/releases/latest"

--- a/patches/freecad-0.20.1-py3.11-support.patch
+++ b/patches/freecad-0.20.1-py3.11-support.patch
@@ -3,7 +3,7 @@ Author: wmayer <wmayer@users.sourceforge.net>
 Date:   Tue Aug 30 15:26:12 2022 +0200
 
     Py: make FreeCAD 0.v20 to compile with Py3.11
-    As requested in this thread: https://forum.freecadweb.org/viewtopic.php?p=622230#p622230
+    As requested in this thread: https://forum.freecad.org/viewtopic.php?p=622230#p622230
 
 diff --git a/src/Base/ConsoleObserver.cpp b/src/Base/ConsoleObserver.cpp
 index c6428a7f18..ab3b3e9157 100644


### PR DESCRIPTION
This PR updates references to the
old FreeCAD site with new ones.

FYI, domains don't mind the casing.