### PR TITLE
pyside2@5.15.15_py312: use locally hosted tarball for patching pyside2@5.15.15_py312

### DIFF
--- a/Formula/pyside2@5.15.15_py312.rb
+++ b/Formula/pyside2@5.15.15_py312.rb
@@ -104,7 +104,6 @@ class Pyside2AT51515Py312 < Formula
       [lib, Formula["qt@5"].opt_lib]
     end
 
-    # ENV.append_path "CMAKE_PREFIX_PATH", Formula["llvm"].opt_lib
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["llvm"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_prefix
     ENV.append_path "CMAKE_PREFIX_PATH", Formula["freecad/freecad/numpy@2.1.1_py312"].opt_prefix
@@ -139,6 +138,7 @@ class Pyside2AT51515Py312 < Formula
       "-DLLVM_CONFIG=#{Formula["llvm"].opt_bin}/llvm-config",
       "-DCMAKE_LIBRARY_PATH=#{Formula["llvm"].opt_lib}",
       "-L",
+      "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
       *cmake_args
 
     system "cmake", "--build", "build"

--- a/Formula/pyside2@5.15.15_py312.rb
+++ b/Formula/pyside2@5.15.15_py312.rb
@@ -71,7 +71,7 @@ class Pyside2AT51515Py312 < Formula
 
   # Apply Debian patches to support Clang >= v15 https://bugreports.qt.io/browse/PYSIDE-2268
   patch do
-    url "http://deb.debian.org/debian/pool/main/p/pyside2/pyside2_5.15.16-1.debian.tar.xz"
+    url "https://github.com/FreeCAD/homebrew-freecad/raw/refs/heads/master/patches/pyside2_5.15.16-1.debian.tar.xz"
     sha256 "3a4b596537c26bac8f94f92256f64f0e30f436f311af7e43197ba34fd13aa5f1"
     apply "patches/shiboken2-clang-Fix-clashes-between-type-name-and-enumera.patch",
           "patches/shiboken2-clang-Fix-and-simplify-resolveType-helper.patch",


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
