### PR TITLE
med-file@4.1.1_py312: set c and cxx std's to c17 with gnu dialect...

### DIFF
--- a/Formula/med-file@4.1.1_py312.rb
+++ b/Formula/med-file@4.1.1_py312.rb
@@ -89,6 +89,10 @@ class MedFileAT411Py312 < Formula
       -DCMAKE_PREFIX_PATH=#{Formula["hdf5"].opt_prefix};#{Formula["gcc"].opt_prefix};
       -DCMAKE_INSTALL_RPATH=#{rpath}
       -DMEDFILE_BUILD_TESTS=0
+      -DCMAKE_C_STANDARD=17
+      -DCMAKE_C_EXTENSIONS=ON
+      -DCMAKE_CXX_STANDARD=17
+      -DCMAKE_CXX_EXTENSIONS=ON
     ]
 
     # remove unwanted values from args


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
