### PR TITLE
[no ci] checkin new patch file to fix build with boost v1.89 or greater

### DIFF
--- a/patches/freecad@1.0.2_py312-fix-build-with-boost-v1.89.patch
+++ b/patches/freecad@1.0.2_py312-fix-build-with-boost-v1.89.patch
@@ -1,0 +1,31 @@
+commit eb4bda1ebb4665dfa9ff76857f25e12a435e8f91
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Tue Sep 23 13:19:35 2025 -0500
+
+    ipatch: fix build with boost version >= v1.89
+
+diff --git a/cMake/FreeCAD_Helpers/SetupBoost.cmake b/cMake/FreeCAD_Helpers/SetupBoost.cmake
+index 0bb1343c3f..ee77e6af03 100644
+--- a/cMake/FreeCAD_Helpers/SetupBoost.cmake
++++ b/cMake/FreeCAD_Helpers/SetupBoost.cmake
+@@ -3,9 +3,18 @@ macro(SetupBoost)
+ 
+     set(_boost_TEST_VERSIONS ${Boost_ADDITIONAL_VERSIONS})
+ 
+-    set (BOOST_COMPONENTS filesystem program_options regex system thread date_time)
++    set (BOOST_COMPONENTS filesystem program_options regex thread date_time)
++
++    find_package(Boost ${BOOST_MIN_VERSION} REQUIRED)
++
++    # add system component if boost version is less than v1.89
++    if(Boost_VERSION_STRING VERSION_LESS "1.89.0")
++      list(APPEND BOOST_COMPONENTS system)
++    endif()
++
++    # now find package with the appropriate components
+     find_package(Boost ${BOOST_MIN_VERSION}
+-        COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
++      COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+ 
+     if(UNIX AND NOT APPLE)
+         # Boost.Thread 1.67+ headers reference pthread_condattr_*


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
