### PR TITLE
[no ci] checkin patch to fix build with newer pcl versions ie. v1.13 and newer

### DIFF
--- a/patches/freecad@1.0.2_py312-fix-with-pcl-v1.15.patch
+++ b/patches/freecad@1.0.2_py312-fix-with-pcl-v1.15.patch
@@ -1,0 +1,23 @@
+commit 992abc1ed8acd68f2ce9e99532745d4b81c8236c
+Author: chris <chris.r.jones.1983@gmail.com>
+Date:   Thu Sep 25 12:55:54 2025 -0500
+
+    fix build error with newer versions of PCL >= v1.13
+
+diff --git a/src/Mod/ReverseEngineering/App/SurfaceTriangulation.cpp b/src/Mod/ReverseEngineering/App/SurfaceTriangulation.cpp
+index 220b1207d5..bad18cbb46 100644
+--- a/src/Mod/ReverseEngineering/App/SurfaceTriangulation.cpp
++++ b/src/Mod/ReverseEngineering/App/SurfaceTriangulation.cpp
+@@ -40,7 +40,11 @@
+ #include <pcl/common/io.h>
+ #include <pcl/features/normal_3d.h>
+ #include <pcl/pcl_config.h>
+-#include <pcl/point_traits.h>
++#if __has_include(<pcl/point_struct_traits.h>)
++#include <pcl/point_struct_traits.h>
++#else
++#include <pcl/type_traits.h>
++#endif
+ #include <pcl/point_types.h>
+ #include <pcl/surface/ear_clipping.h>
+ #include <pcl/surface/gp3.h>


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
