### PR TITLE
fc_bundle_py312: update formula to use versioned vtk

### DIFF
--- a/Formula/fc_bundle_py312.rb
+++ b/Formula/fc_bundle_py312.rb
@@ -26,6 +26,7 @@ class FcBundlePy312 < Formula
   depends_on "freecad/freecad/numpy@2.1.1_py312"
   depends_on "freecad/freecad/pybind11_py312"
   depends_on "freecad/freecad/pyside2@5.15.15_py312" # pyside includes the shiboken2 module as well
+  depends_on "freecad/freecad/vtk@9.5.2_py312"
   depends_on "freetype"
   depends_on "geos"
   # epends_on "libxau" if OS.linux?
@@ -157,6 +158,8 @@ class FcBundlePy312 < Formula
       ).strip
     pyside2_pth_contents =
       File.read("#{Formula["pyside2@5.15.15_py312"].opt_prefix}/lib/python#{pyver}/pyside2.pth").strip
+    vtk_pth_contents =
+      File.read("#{Formula["vtk@9.5.2_py312"].opt_prefix}/lib/python#{pyver}/vtk_py312.pth").strip
 
     site_packages = Language::Python.site_packages("python3.12")
     # {shiboken2_pth_contents}
@@ -166,6 +169,7 @@ class FcBundlePy312 < Formula
       #{numpy_pth_contents}
       #{pybind11_pth_contents}
       #{pyside2_pth_contents}
+      #{vtk_pth_contents}
       #{venv_dir}/lib/python#{pyver}/site-packages
     EOS
     (prefix/site_packages/"freecad-py-modules.pth").write pth_contents


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
