### PR TITLE
[no ci] remove references to python@3.9 and rm bottles for affected formula

### DIFF
--- a/Formula/opencascade@7.5.0.rb
+++ b/Formula/opencascade@7.5.0.rb
@@ -10,19 +10,14 @@ class OpencascadeAT750 < Formula
     regex(/href=.*?opencascade[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  bottle do
-    root_url "https://github.com/freecad/homebrew-freecad/releases/download/07.28.2021"
-    sha256 cellar: :any, big_sur:   "1f625aeaef44b9a78714fae89f5feaa79ce43ae1515b3cb6139cfce3d603e412"
-    sha256 cellar: :any, catalina:  "721771a181d3d8b3c2863df9ebf91d6f50e858ef81ed9cf2440c60bc6569fcc8"
-    sha256 cellar: :any, mojave:    "7653f9d90250ae0d221578e93ac533d048f8c63ecb6932d9fe84519a838ba028"
-  end
+  disable! date: "2025-10-20", because: "no longer required"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "rapidjson" => :build
-  depends_on "freecad/freecad/tbb@2020_u3"
   depends_on "freeimage"
   depends_on "freetype"
+  depends_on "tbb"
 
   def install
     system "cmake", ".",

--- a/Formula/opencascade@7.5.3.rb
+++ b/Formula/opencascade@7.5.3.rb
@@ -20,14 +20,16 @@ class OpencascadeAT753 < Formula
     end
   end
 
-  keg_only :versioned_formula # NOTE: homebrewcore provides opencascade too
+  keg_only :versioned_formula
+
+  disable! date: "2025-10-20", because: "no longer required" # NOTE: homebrewcore provides opencascade too
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "rapidjson" => :build
-  depends_on "freecad/freecad/tbb@2020_u3"
   depends_on "freeimage"
   depends_on "freetype"
+  depends_on "tbb"
   depends_on "tcl-tk"
 
   # NOTE: https://tracker.dev.opencascade.org/view.php?id=32328

--- a/Formula/opencascade@7.6.0.rb
+++ b/Formula/opencascade@7.6.0.rb
@@ -20,14 +20,16 @@ class OpencascadeAT760 < Formula
   #   end
   # end
 
-  keg_only :versioned_formula # NOTE: homebrewcore provides opencascade too
+  keg_only :versioned_formula
+
+  disable! date: "2025-10-20", because: "no longer required" # NOTE: homebrewcore provides opencascade too
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "rapidjson" => :build
-  depends_on "freecad/freecad/tbb@2020_u3"
   depends_on "freeimage"
   depends_on "freetype"
+  depends_on "tbb"
   depends_on "tcl-tk"
 
   def install

--- a/Formula/opencascade@7.7.2.rb
+++ b/Formula/opencascade@7.7.2.rb
@@ -19,19 +19,12 @@ class OpencascadeAT772 < Formula
     end
   end
 
-  bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "3c2362f5b8a6424caacc6ba9f8d73761a72f23dbb967aeca78d0c21c5bd40648"
-    sha256 cellar: :any,                 arm64_sonoma:  "645b8bcc26c114ee5822f063b4e4f43d305e3723834082dbe58e972734090ad2"
-    sha256 cellar: :any,                 ventura:       "9b6032c9e0007bdbc951498e85350a5294f197ed433f063de67cb51f46867219"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9a7cf40240dede922304079568cd325d221f89ea88649970e0afc84d728cd3b0"
-  end
+  keg_only :versioned_formula
+
+  disable! date: "2025-10-20", because: "no longer required"
 
   # NOTE: ipatch, this formula file was copied from
   # https://github.com/Homebrew/homebrew-core/blob/029de2514455bb00b99d0785896fdfdc58882293/Formula/o/opencascade.rb
-
-  keg_only :versioned_formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "doxygen" => :build

--- a/Formula/tbb@2020_u3.rb
+++ b/Formula/tbb@2020_u3.rb
@@ -9,9 +9,11 @@ class TbbAT2020U3 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2025-10-20", because: "no longer required, use onetbb from homebrew/core"
+
   depends_on "cmake" => :build
   depends_on "freecad/freecad/swig@4.0.2" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.12"
 
   # Remove when upstream fix is released
   # https://github.com/oneapi-src/oneTBB/pull/258
@@ -38,7 +40,7 @@ class TbbAT2020U3 < Formula
 
     cd "python" do
       ENV["TBBROOT"] = prefix
-      python3 = Formula["python@3.9"].opt_bin/"python3"
+      python3 = Formula["python@3.12"].opt_bin/"python3"
       system python3, *Language::Python.setup_install_args(prefix)
     end
 
@@ -81,7 +83,5 @@ class TbbAT2020U3 < Formula
 
     system ENV.cxx, "sum1-100.cpp", "--std=c++14", "-L#{lib}", "-I#{include}", "-ltbb", "-o", "sum1-100"
     assert_equal "5050", shell_output("./sum1-100").chomp
-
-    # system "#{HOMEBREW_PREFIX}/bin/python3", "-c", "import tbb"
   end
 end


### PR DESCRIPTION
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
