### PR TITLE
freecad@1.0.2_py313_qt6: bump revision of formula to trigger a rebuild

### DIFF
--- a/Formula/freecad@1.0.2_py313_qt6.rb
+++ b/Formula/freecad@1.0.2_py313_qt6.rb
@@ -5,7 +5,7 @@ class FreecadAT102Py313Qt6 < Formula
   desc "Parametric 3D modeler"
   homepage "https://freecad.org/"
   license "GPL-2.0-only"
-  revision 4
+  revision 5
 
   PY_VER = "3.13".freeze
 

--- a/Formula/freecad@1.0.2_py313_qt6.rb
+++ b/Formula/freecad@1.0.2_py313_qt6.rb
@@ -16,6 +16,12 @@ class FreecadAT102Py313Qt6 < Formula
     url "https://github.com/FreeCAD/FreeCAD/archive/refs/tags/1.0.2.tar.gz"
     sha256 "228ee52f00627c7d8fa61998179deb01865ece69390829feb1300228d24f7e9e"
 
+    # fix bld with qt v6.11
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
+      sha256 "d7857d23e9c9227ab935085190be7330fc69872c4e1cf03d91c44116e0765f1f"
+    end
+
     # fix build with newer versions of PCL ie. >= 1.15
     patch do
       url "https://github.com/freecad/freecad/commit/d9e731ca94abc14808ebeed208617116f6d5ea4a.patch?full_index=1"

--- a/Formula/freecad@1.0.2_py313_qt6.rb
+++ b/Formula/freecad@1.0.2_py313_qt6.rb
@@ -19,7 +19,7 @@ class FreecadAT102Py313Qt6 < Formula
     # fix bld with qt v6.11
     patch do
       url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
-      sha256 "d7857d23e9c9227ab935085190be7330fc69872c4e1cf03d91c44116e0765f1f"
+      sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
     end
 
     # fix build with newer versions of PCL ie. >= 1.15


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
