### PR TITLE
freecad@1.1.0_py313_qt6: update alias in tap to point to new freecad release ie. v1.1.0 [no ci]

### DIFF
--- a/Aliases/freecad
+++ b/Aliases/freecad
@@ -1,1 +1,1 @@
-../Formula/freecad@1.0.2_py313_qt6.rb
+../Formula/freecad@1.1.0_py313_qt6.rb

--- a/Formula/freecad@1.1.0_py313_qt6.rb
+++ b/Formula/freecad@1.1.0_py313_qt6.rb
@@ -7,21 +7,6 @@ class FreecadAT110Py313Qt6 < Formula
   license "GPL-2.0-only"
   revision 1
 
-  bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    sha256 cellar: :any, arm64_tahoe:   "6f66db6d62bf3a19d00d44b571aac59f66362ae66574c2f0ec18c72de1c787c1"
-    sha256 cellar: :any, arm64_sequoia: "bb108536dacaa54e07b450109845b9bfd3cf6bafd3f7c742f34f841ec4f4915f"
-    sha256 cellar: :any, arm64_sonoma:  "a35ae5e9e7cf83ba3422451393ca6956632be3250290efdc08fac42e11af8d6c"
-    sha256               x86_64_linux:  "941153e87519fc5d3ee0df9856197a3f8873c5a867b295b82eeb2a5472b877b4"
-  end
-
-  PY_VER = "3.13".freeze
-  VERSION_COMMIT_REF = "34a9716668".freeze
-  VERSION_COMMIT_DATE = "2026-03-24 23:17:53 -0300".freeze
-
-  # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`
-  # run `brew cleanup` when editing local patch files on each subsequent `brew install`
-  #---
   stable do
     url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.0/freecad_source_1.1.0.tar.gz"
     sha256 "3d041561aa129755eea51dfc0e1cdf43f2623ab06538e0860a91dbef1ae433d7"
@@ -73,6 +58,22 @@ class FreecadAT110Py313Qt6 < Formula
       sha256 "0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd"
     end
   end
+
+  bottle do
+    root_url "https://ghcr.io/v2/freecad/freecad"
+    sha256 cellar: :any, arm64_tahoe:   "6f66db6d62bf3a19d00d44b571aac59f66362ae66574c2f0ec18c72de1c787c1"
+    sha256 cellar: :any, arm64_sequoia: "bb108536dacaa54e07b450109845b9bfd3cf6bafd3f7c742f34f841ec4f4915f"
+    sha256 cellar: :any, arm64_sonoma:  "a35ae5e9e7cf83ba3422451393ca6956632be3250290efdc08fac42e11af8d6c"
+    sha256               x86_64_linux:  "941153e87519fc5d3ee0df9856197a3f8873c5a867b295b82eeb2a5472b877b4"
+  end
+
+  PY_VER = "3.13".freeze
+  VERSION_COMMIT_REF = "34a9716668".freeze
+  VERSION_COMMIT_DATE = "2026-03-24 23:17:53 -0300".freeze
+
+  # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`
+  # run `brew cleanup` when editing local patch files on each subsequent `brew install`
+  #---
 
   head do
     url "https://github.com/freecad/FreeCAD.git", branch: "main", shallow: false


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
