### PR TITLE
freecad@1.1.1_py313_qt6: fix build error with recent versions of pcl

### DIFF
--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -391,9 +391,6 @@ class FreecadAT111Py313Qt6 < Formula
     # --trace
     # -L
 
-    ENV.remove "PATH", Formula["pyside@2"].opt_prefix/"bin"
-
-    ENV.remove "PKG_CONFIG_PATH", Formula["pyside@2"].opt_prefix/"lib/pkgconfig"
     ENV.remove "PKG_CONFIG_PATH", Formula["qt@5"].opt_prefix/"lib/pkgconfig"
 
     ENV.remove "CMAKE_FRAMEWORK_PATH", Formula["qt@5"].opt_prefix/"Frameworks"

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -110,6 +110,7 @@ class FreecadAT111Py313Qt6 < Formula
   depends_on "cython"
   depends_on "doxygen"
   depends_on "expat"
+  depends_on "flann"
   depends_on "fmt"
   depends_on "fontconfig" if OS.linux?
   depends_on "freecad/freecad/calculix@2.23"
@@ -204,6 +205,7 @@ class FreecadAT111Py313Qt6 < Formula
     cmake_prefix_paths << Formula["doxygen"].prefix
     cmake_prefix_paths << Formula["eigen"].prefix
     cmake_prefix_paths << Formula["expat"].prefix
+    cmake_prefix_paths << Formula["flann"].prefix
     cmake_prefix_paths << Formula["fmt"].prefix
     cmake_prefix_paths << Formula["freeimage"].prefix
     cmake_prefix_paths << Formula["freetype"].prefix
@@ -344,6 +346,9 @@ class FreecadAT111Py313Qt6 < Formula
 
     ninja_bin = Formula["ninja"].opt_bin/"ninja"
 
+    # NOTE: when build with PCL enabled recent versions of pcl have updated to "imported targets"
+    ENV.append "CXXFLAGS", "-isystem #{Formula["flann"].include}"
+
     args = %W[
       -DHOMEBREW_PREFIX=#{hbp}
       -DCMAKE_PREFIX_PATH=#{cmake_prefix_path_string}
@@ -366,9 +371,10 @@ class FreecadAT111Py313Qt6 < Formula
       -DFREECAD_USE_PYBIND11:BOOL=ON
       -DFREECAD_USE_EXTERNAL_KDL:BOOL=ON
       -DBUILD_FEM_NETGEN=:BOOL=ON
-      -DFREECAD_USE_PCL:BOOL=ON
       -DFREECAD_LIBPACK_USE:BOOL=OFF
       -DBUILD_WITH_CONDA:BOOL=OFF
+
+      -DFREECAD_USE_PCL:BOOL=ON
 
       -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=FALSE
       -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=FALSE


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
