### PR TITLE
freecad@1.1.1_py313_qt6: experiment with running non gui test suite

### DIFF
--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -10,6 +10,12 @@ class FreecadAT111Py313Qt6 < Formula
     url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/freecad_source_1.1.1.tar.gz"
     sha256 "c0e95d41415f1e73bfe2e0a0a28210f649b01ef531bbfed1ed15863950dc5381"
 
+    # fix bld with pyside 6.11
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/1c599a2248.patch?full_index=1"
+      sha256 "e4895af708867eb45b4195f3e40eb330108a8fa8081aee5e2e17ff01f06d9f86"
+    end
+
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983
     patch do

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -10,6 +10,12 @@ class FreecadAT111Py313Qt6 < Formula
     url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/freecad_source_1.1.1.tar.gz"
     sha256 "c0e95d41415f1e73bfe2e0a0a28210f649b01ef531bbfed1ed15863950dc5381"
 
+    # fix bld with cam/path wb failing test in test module, ie. test 46/47
+    patch do
+      url "https://github.com/FreeCAD/homebrew-freecad/commit/e65fa785e44f21337c91cd80fc42ea0d5909a8f4.patch?full_index=1"
+      sha256 "0638459a47f997fbf007d709321e1230011ed98cd8216616c8bffceb588e3ac5"
+    end
+
     # fix bld with pyside 6.11
     patch do
       url "https://github.com/FreeCAD/FreeCAD/commit/1c599a2248.patch?full_index=1"

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -526,10 +526,11 @@ class FreecadAT111Py313Qt6 < Formula
 
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
-    with_env(HOME:            testpath,
-             XDG_CONFIG_HOME: "#{testpath}/config",
-             XDG_CACHE_HOME:  "#{testpath}/cache",
-             XDG_DATA_HOME:   "#{testpath}/data") do
+    with_env(
+             "FREECAD_USER_HOME" => testpath.to_s,
+             "FREECAD_USER_DATA" => testpath.to_s,
+             "FREECAD_USER_TEMP" => testpath.to_s,
+    ) do
       system freecadcmd, "-t", "0"
     end
   end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -527,9 +527,9 @@ class FreecadAT111Py313Qt6 < Formula
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
     with_env(
-             "FREECAD_USER_HOME" => testpath.to_s,
-             "FREECAD_USER_DATA" => testpath.to_s,
-             "FREECAD_USER_TEMP" => testpath.to_s,
+      "FREECAD_USER_HOME" => testpath.to_s,
+      "FREECAD_USER_DATA" => testpath.to_s,
+      "FREECAD_USER_TEMP" => testpath.to_s,
     ) do
       system freecadcmd, "-t", "0"
     end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -12,8 +12,8 @@ class FreecadAT111Py313Qt6 < Formula
 
     # fix bld with cam/path wb failing test in test module, ie. test 46/47
     patch do
-      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/4b04a4bdb5b8211f329316aacc5bdd28b357054e/patches/freecad@1.1.1_py313_qt6-fix-cam-failing-tests.patch"
-      sha256 "e14a18c56cf693471898144c8a523aecccc5d6b3f3260045b043133c783c609b"
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
+      sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
     end
 
     # fix bld with pyside 6.11

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -526,11 +526,11 @@ class FreecadAT111Py313Qt6 < Formula
 
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
-    with_env(HOME: testpath, TMPDIR: testpath) do
-      system freecadcmd, "-u", testpath/"user.cfg",
-        "-s", testpath/"system.cfg",
-        "-t", "0"
+    with_env(HOME:            testpath,
+             XDG_CONFIG_HOME: "#{testpath}/config",
+             XDG_CACHE_HOME:  "#{testpath}/cache",
+             XDG_DATA_HOME:   "#{testpath}/data") do
+      system freecadcmd, "-t", "0"
     end
-    system freecadcmd, "-t", "0"
   end
 end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -12,8 +12,8 @@ class FreecadAT111Py313Qt6 < Formula
 
     # fix bld with cam/path wb failing test in test module, ie. test 46/47
     patch do
-      url "https://github.com/FreeCAD/homebrew-freecad/commit/4b04a4bdb5b8211f329316aacc5bdd28b357054e.patch?full_index=1"
-      sha256 "a8ff8e724f560053fe102b80a0802f1fcde355d9e3d081c846a9c05e9a6b1aca"
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/4b04a4bdb5b8211f329316aacc5bdd28b357054e/patches/freecad@1.1.1_py313_qt6-fix-cam-failing-tests.patch"
+      sha256 "e14a18c56cf693471898144c8a523aecccc5d6b3f3260045b043133c783c609b"
     end
 
     # fix bld with pyside 6.11

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -526,6 +526,11 @@ class FreecadAT111Py313Qt6 < Formula
 
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
+    with_env(HOME: testpath, TMPDIR: testpath) do
+      system freecadcmd, "-u", testpath/"user.cfg",
+        "-s", testpath/"system.cfg",
+        "-t", "0"
+    end
     system freecadcmd, "-t", "0"
   end
 end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -505,7 +505,6 @@ class FreecadAT111Py313Qt6 < Formula
   end
 
   test do
-    # NOTE: make test more robust and accurate
-    system "true"
+    system bin/"FreeCADCmd", "-t", "0"
   end
 end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -485,6 +485,14 @@ class FreecadAT111Py313Qt6 < Formula
 
   def post_install
     ohai "the value of prefix = #{prefix}"
+
+    # mac bundle drops FreeCAD's PySide shim in MacOS/; FreeCAD's sys.path
+    # expects it in Ext/ (as on Linux). Relocate so `import PySide` resolves.
+    if OS.mac?
+      (prefix/"Ext/PySide").dirname.mkpath
+      mv prefix/"MacOS/PySide", prefix/"Ext/PySide"
+    end
+
     if OS.mac?
       ln_s "#{prefix}/MacOS/FreeCAD", "#{HOMEBREW_PREFIX}/bin/freecad", force: true
       ln_s "#{prefix}/MacOS/FreeCADCmd", "#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
@@ -517,6 +525,7 @@ class FreecadAT111Py313Qt6 < Formula
   end
 
   test do
-    system bin/"FreeCADCmd", "-t", "0"
+    freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
+    system freecadcmd, "-t", "0"
   end
 end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -12,8 +12,8 @@ class FreecadAT111Py313Qt6 < Formula
 
     # fix bld with cam/path wb failing test in test module, ie. test 46/47
     patch do
-      url "https://github.com/FreeCAD/homebrew-freecad/commit/e65fa785e44f21337c91cd80fc42ea0d5909a8f4.patch?full_index=1"
-      sha256 "0638459a47f997fbf007d709321e1230011ed98cd8216616c8bffceb588e3ac5"
+      url "https://github.com/FreeCAD/homebrew-freecad/commit/4b04a4bdb5b8211f329316aacc5bdd28b357054e.patch?full_index=1"
+      sha256 "a8ff8e724f560053fe102b80a0802f1fcde355d9e3d081c846a9c05e9a6b1aca"
     end
 
     # fix bld with pyside 6.11

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -142,7 +142,6 @@ class FreecadAT111Py313Qt6 < Formula
   depends_on "libomp"
   depends_on "libx11" if OS.linux?
   depends_on "llvm" if OS.linux?
-  depends_on macos: :ventura # because qt v6
   depends_on "mesa" if OS.linux?
   depends_on "mesa-glu" if OS.linux?
   depends_on "nlohmann-json"
@@ -159,12 +158,15 @@ class FreecadAT111Py313Qt6 < Formula
   depends_on "qtsvg"
   depends_on "qttools"
   depends_on "tbb"
-  depends_on "vtk" # upstream homebrew-core vtk indirect link due to pcl
+  depends_on "vtk"
   depends_on "vulkan-headers"
   depends_on "webp"
   depends_on "xerces-c"
   depends_on "yaml-cpp"
   depends_on "zlib-ng-compat"
+  on_macos do
+    depends_on macos: :ventura # because qt v6
+  end
 
   def install
     hbp = HOMEBREW_PREFIX

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -400,8 +400,8 @@ class FreecadAT111Py313Qt6 < Formula
 
     # NOTE: ipatch, the required vars were required to get cmake to configure freecad on ubuntu 22.04
     if OS.linux? && File.exist?("/etc/os-release") &&
-        File.read("/etc/os-release").include?('VERSION_ID="22.04"')
-      qt_module_prefixes = %w[qtsvg qttools].map { |f| Formula[f].opt_prefix }
+       File.read("/etc/os-release").include?('VERSION_ID="22.04"')
+      qt_module_prefixes = %w[qtsvg qttools qtbase].map { |f| formula_opt_prefix(f) }
       args << "-DQT_ADDITIONAL_PACKAGES_PREFIX_PATH=#{qt_module_prefixes.join(";")}"
     end
 

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -387,6 +387,7 @@ class FreecadAT111Py313Qt6 < Formula
       -DBUILD_WITH_CONDA:BOOL=OFF
 
       -DFREECAD_USE_PCL:BOOL=ON
+      -DVTK_DIR=#{formula_opt_lib("freecad/freecad/vtk@9.5.2_py313")}/cmake/vtk-9.5
 
       -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=FALSE
       -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=FALSE

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -340,6 +340,7 @@ class FreecadAT111Py313Qt6 < Formula
       med_lib = formula_opt_lib("med-file@5.0.0_py313")
       netgen_lib = formula_opt_lib("netgen@6.2.2601")
       pyside6_lib = formula_opt_lib("pyside6_py313")
+      vtk_lib = formula_opt_lib("vtk@9.5.2_py313")
 
       args_linux_only = %W[
         -DX11_X11_INCLUDE_PATH=#{hbp}/opt/libx11/include/X11
@@ -351,7 +352,7 @@ class FreecadAT111Py313Qt6 < Formula
         -DCMAKE_EXE_LINKER_FLAGS=#{linux_linker_flags}
         -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld
         -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld
-        -DCMAKE_INSTALL_RPATH=#{hbp}/lib;#{coin_lib};#{libomp_lib};#{med_lib};#{netgen_lib};#{pyside6_lib}
+        -DCMAKE_INSTALL_RPATH=#{hbp}/lib;#{coin_lib};#{libomp_lib};#{med_lib};#{netgen_lib};#{pyside6_lib};#{vtk_lib}
         -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
       ]
     end
@@ -396,6 +397,15 @@ class FreecadAT111Py313Qt6 < Formula
 
       -L
     ]
+
+    # NOTE: ipatch, the required vars were required to get cmake to configure freecad on ubuntu 22.04
+    if OS.linux? && File.exist?("/etc/os-release") &&
+        File.read("/etc/os-release").include?('VERSION_ID="22.04"')
+      qt_module_prefixes = %w[qtsvg qttools].map { |f| Formula[f].opt_prefix }
+      args << "-DQT_ADDITIONAL_PACKAGES_PREFIX_PATH=#{qt_module_prefixes.join(";")}"
+    end
+
+    args << "--debug-find-pkg=VTK"
 
     # TODO: probably requires a separate formula to post_install the freecad py module
     args << "-DINSTALL_TO_SITEPACKAGES=OFF"

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -281,7 +281,7 @@ class FreecadAT111Py313Qt6 < Formula
       cmake_ld = "/Library/Developer/CommandLineTools/usr/bin/ld"
     end
 
-    # TODO: stub out the below cmake vars
+    # NOTE: the below cmake vars can be stubbed out ie. set
     # -DCMAKE_OSX_SYSROOT=#{cmake_osx_sysroot}
     # -DCMAKE_CXX_FLAGS="-fuse-ld=lld"
     # -DBUILD_ENABLE_CXX_STD=C++17 # freecad v1.1.0 now reqs C++20
@@ -362,6 +362,9 @@ class FreecadAT111Py313Qt6 < Formula
     # NOTE: when build with PCL enabled recent versions of pcl have updated to "imported targets"
     ENV.append "CXXFLAGS", "-isystem #{Formula["flann"].include}"
 
+    # NOTE: tbb circa aug 2026 is giving missing header error ie. blocked_range.h
+    ENV.append "CXXFLAGS", "-isystem #{Formula["tbb"].include}"
+
     args = %W[
       -DHOMEBREW_PREFIX=#{hbp}
       -DCMAKE_PREFIX_PATH=#{cmake_prefix_path_string}
@@ -398,7 +401,7 @@ class FreecadAT111Py313Qt6 < Formula
       -L
     ]
 
-    # NOTE: ipatch, the required vars were required to get cmake to configure freecad on ubuntu 22.04
+    # NOTE: ipatch, the below vars were required to get cmake to configure freecad on ubuntu 22.04
     if OS.linux? && File.exist?("/etc/os-release") &&
        File.read("/etc/os-release").include?('VERSION_ID="22.04"')
       qt_module_prefixes = %w[qtsvg qttools qtbase].map { |f| formula_opt_prefix(f) }

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -331,6 +331,7 @@ class FreecadAT111Py313Qt6 < Formula
       # NOTE: ipatch, linker req because, https://github.com/FreeCAD/homebrew-freecad/issues/546
       linux_linker_flags = "-L#{HOMEBREW_PREFIX}/opt/gcc/lib/gcc/current " \
                            "-Wl,-rpath,#{HOMEBREW_PREFIX}/opt/gcc/lib/gcc/current " \
+                           "-L#{formula_opt_lib("tbb")} -ltbb " \
                            "-fuse-ld=lld"
 
       # NOTE: these are keg-only formula thus their libs do not exist in #{hbp}/lib
@@ -541,7 +542,6 @@ class FreecadAT111Py313Qt6 < Formula
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
     if OS.mac?
-      require "fileutils"
       # getCustomPaths() drops FREECAD_USER_HOME if the dir doesn't already exist
       # brew test chdirs into a bare testpath, so pre-create it.
       mkdir_p [

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -503,7 +503,7 @@ class FreecadAT111Py313Qt6 < Formula
 
     # mac bundle drops FreeCAD's PySide shim in MacOS/; FreeCAD's sys.path
     # expects it in Ext/ (as on Linux). Relocate so `import PySide` resolves.
-    if OS.mac?
+    if OS.mac? && (prefix/"MacOS/PySide").exist?
       (prefix/"Ext/PySide").dirname.mkpath
       mv prefix/"MacOS/PySide", prefix/"Ext/PySide"
     end
@@ -542,14 +542,19 @@ class FreecadAT111Py313Qt6 < Formula
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
     if OS.mac?
-      # getCustomPaths() drops FREECAD_USER_HOME if the dir doesn't already exist
-      # brew test chdirs into a bare testpath, so pre-create it.
-      mkdir_p [
-        testpath/"Library/Application Support/FreeCAD",
-        testpath/"Library/Preferences/FreeCAD",
-        testpath/"Library/Caches/FreeCAD",
-      ]
-      # macos only honors FREECAD_USER_HOME, sort of an upstream bug that should be fixed
+      # FreeCAD's App::ApplicationDirectories::configurePaths() calls
+      # create_directories() on NSHomeDirectory()-derived paths during
+      # initConfig(). NSHomeDirectory() resolves via getpwuid(), so neither
+      # $HOME nor FREECAD_USER_HOME/_USER_DATA/_USER_TEMP redirect it, and a
+      # filesystem_error there escapes to main() -- FreeCAD then reports only
+      # "Unknown runtime error occurred while initializing FreeCAD".
+      #
+      # Homebrew sandboxes build, test and postinstall on macOS, so those
+      # directories cannot be created from this formula. CI pre-creates them
+      # (see the "Pre-create FreeCAD state dirs" step in tests.yml).
+      # Running `brew test` locally on a machine that has never run FreeCAD
+      # will fail until upstream stops treating that failure as fatal.
+      # TODO: file an upstream issue, and possibly a PR that fixes the issue.
       with_env("FREECAD_USER_HOME" => testpath.to_s, "TMPDIR" => testpath.to_s) do
         system freecadcmd, "-t", "0"
       end

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -538,8 +538,16 @@ class FreecadAT111Py313Qt6 < Formula
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
     if OS.mac?
+      require "fileutils"
+      # getCustomPaths() drops FREECAD_USER_HOME if the dir doesn't already exist
+      # brew test chdirs into a bare testpath, so pre-create it.
+      mkdir_p [
+        testpath/"Library/Application Support/FreeCAD",
+        testpath/"Library/Preferences/FreeCAD",
+        testpath/"Library/Caches/FreeCAD",
+      ]
       # macos only honors FREECAD_USER_HOME, sort of an upstream bug that should be fixed
-      with_env("FREECAD_USER_HOME" => testpath.to_s) do
+      with_env("FREECAD_USER_HOME" => testpath.to_s, "TMPDIR" => testpath.to_s) do
         system freecadcmd, "-t", "0"
       end
     else

--- a/Formula/freecad@1.1.1_py313_qt6.rb
+++ b/Formula/freecad@1.1.1_py313_qt6.rb
@@ -537,12 +537,19 @@ class FreecadAT111Py313Qt6 < Formula
 
   test do
     freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
-    with_env(
-      "FREECAD_USER_HOME" => testpath.to_s,
-      "FREECAD_USER_DATA" => testpath.to_s,
-      "FREECAD_USER_TEMP" => testpath.to_s,
-    ) do
-      system freecadcmd, "-t", "0"
+    if OS.mac?
+      # macos only honors FREECAD_USER_HOME, sort of an upstream bug that should be fixed
+      with_env("FREECAD_USER_HOME" => testpath.to_s) do
+        system freecadcmd, "-t", "0"
+      end
+    else
+      with_env(
+        "FREECAD_USER_HOME" => testpath.to_s,
+        "FREECAD_USER_DATA" => testpath.to_s,
+        "FREECAD_USER_TEMP" => testpath.to_s,
+      ) do
+        system freecadcmd, "-t", "0"
+      end
     end
   end
 end


### PR DESCRIPTION
**update june 26 2026**

started the below homebrew discussion about the permission issues posted in this PR.

- https://github.com/orgs/Homebrew/discussions/6926

**update june 24 2026**

basically certain tests from the test suite are failing on macos due to permission related issues possibly because of some new homebrew sandboxing that has recently been enforced 🤔. hopefully setting an env var for the CI environment will be enough, but will continue to troubleshoot time permitting.

**latest error messages**

<details>
<summary>error messages</summary>

```
==> Testing freecad/freecad/freecad@1.1.1_py313_qt6
==> /opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/MacOS/FreeCADCmd -u /private/tmp/freecadA1.1.1_py313_qt6-test-20260622-40314-vv4ai1/user.cfg -s /private/tmp/freecadA1.1.1_py313_qt6-test-20260622-40314-vv4ai1/system.cfg -t 0
Fatal Python error: take_gil: PyMUTEX_LOCK(gil->mutex) failed
Python runtime state: unknown

While initializing FreeCAD the following exception occurred: 'Could not create directories. Failed with: Operation not permitted'
```

```
Python is searching for its runtime files in the following directories:
::error::freecad/freecad/freecad@1.1.1_py313_qt6: failed
An exception occurred within a child process:
  BuildError: Failed executing: /opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/MacOS/FreeCADCmd -u /private/tmp/freecadA1.1.1_py313_qt6-test-20260622-40314-vv4ai1/user.cfg -s /private/tmp/freecadA1.1.1_py313_qt6-test-20260622-40314-vv4ai1/system.cfg -t 0
/opt/homebrew/Library/Homebrew/formula.rb:3589:in 'block in Formula#system'
/opt/homebrew/Library/Homebrew/formula.rb:3525:in 'IO.open'
/opt/homebrew/Library/Homebrew/formula.rb:3525:in 'Formula#system'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/4.0.0/gems/sorbet-runtime-0.6.13296/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
```

```
==> Testing freecad/freecad/freecad@1.1.1_py313_qt6
==> /opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/MacOS/FreeCADCmd -t 0
Error: Failed to open library "/Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib"! Error: dlopen(/Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib, 0x0005): tried: '/Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib' (no such file), '/Library/Frameworks/3DconnexionNavlib.framework/3DconnexionNavlib' (no such file)!
Traceback (most recent call last):
  File "<string>", line 39, in <module>
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Test/TestApp.py", line 85, in TestText
    s = unittest.defaultTestLoader.loadTestsFromName(s)
  File "/opt/homebrew/Cellar/python@3.13/3.13.14/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/loader.py", line 192, in loadTestsFromName
    test = obj()
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Test/TestApp.py", line 65, in All
    suite.addTest(tryLoadingTest(test))
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Test/TestApp.py", line 38, in tryLoadingTest
    return unittest.defaultTestLoader.loadTestsFromName(testName)
  File "/opt/homebrew/Cellar/python@3.13/3.13.14/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/loader.py", line 137, in loadTestsFromName
    module = __import__(module_name)
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/TestCAMApp.py", line 27, in <module>
    from CAMTests.TestCAMSanity import TestCAMSanity
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/CAMTests/TestCAMSanity.py", line 26, in <module>
    from Path.Main.Sanity import ReportGenerator, Sanity
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/Path/Main/Sanity/Sanity.py", line 41, in <module>
    import Path.Dressup.Utils as PathDressup
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/Path/Dressup/Utils.py", line 25, in <module>
    import Path.Main.Job as PathJob
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/Path/Main/Job.py", line 24, in <module>
    from Path.Post.Processor import PostProcessorFactory  # PostProcessor,
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/Path/Post/Processor.py", line 41, in <module>
    import Path.Post.UtilsExport as PostUtilsExport
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/CAM/Path/Post/UtilsExport.py", line 39, in <module>
    imp<class 'PermissionError'>: [Errno 1] Operation not permitted: '/Users/runner/Library/Application Support/FreeCAD/v1-1/CamAssets'
FreeCAD 1.1.1, Libs: 1.1.1R0108fd4b48
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.
```

```
testSaveAndRestore (UnicodeTests.DocumentSaveRestoreCases.testSaveAndRestore) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_80850d3f-1dd2-4289-af84-a49db2b7d8b9_da39a3_898521'
Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_80850d3f-1dd2-4289-af84-a49db2b7d8b9_608586_898521'
Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_4dc8f181-1ca8-4c4f-93ae-12c1632b27ea_da39a3_898521'
Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_80850d3f-1dd2-4289-af84-a49db2b7d8b9_608586_898521'
Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_9ff66f0b-1a45-4ecf-89a0-450d738faeed_da39a3_898521'
ok
testUnicodeLabel (UnicodeTests.UnicodeBasicCases.testUnicodeLabel) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_4a6f1256-f25f-4e0f-b5cf-8eff31854da7_da39a3_898521'
ok
testAll (TestPythonSyntax.PythonSyntaxTestCase.testAll) ... <unknown>:25: SyntaxWarning: invalid escape sequence '\K'
ok
test_00print (femtest.app.test_femimport.TestFemImport.test_00print) ... ok
test_import_fem (femtest.app.test_femimport.TestFemImport.test_import_fem) ... ok
test_00print (femtest.app.test_common.TestFemCommon.test_00print) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_5ce3f072-a0d5-4edc-b09c-23ae9b261571_da39a3_898521'
ok
test_adding_refshaps (femtest.app.test_common.TestFemCommon.test_adding_refshaps) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_bfd661e0-be38-46f8-855b-397680918293_da39a3_898521'
ok
test_pyimport_all_FEM_modules (femtest.app.test_common.TestFemCommon.test_pyimport_all_FEM_modules) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_8a743cb5-11bd-4411-8c05-668db13c0022_da39a3_898521'
Module pyNastran not found. Writing Mystran solver input will not work.
FEM: VTK Python module is not compatible with internal VTK libraryok
test_00print (femtest.app.test_object.TestObjectCreate.test_00print) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_ba5477a7-8244-4052-811c-1782229b0c91_da39a3_898521'
ok
test_femobjects_make (femtest.app.test_object.TestObjectCreate.test_femobjects_make) ... Failed to create '/Users/runner/Library/Caches/FreeCAD/v1-1/Cache/FreeCAD_Doc_cabc849f-f712-4311-94ff-ac1ee370d82a_da39a3_898521'
```

</details>



- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
