### PR TITLE
fc_bundle_py313_qt6: bump revision so github ci finds the correct .pth file for pyside6_py313

### DIFF
--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -10,7 +10,7 @@ class FcBundlePy313Qt6 < Formula
   version "1.1.1"
   # sha of file:///dev/null
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"


### PR DESCRIPTION
since i updated the `pyside6_py313` formula a while back, and bumped the revision, and did not update this meta package the `freecad@1.1.1_py313_qt6` formula will fail when running `./freecadcmd -t 0` due to finding the incorrect revision of the build for the pyside6_py313 package ie. the `_01` vs. the `_02`. so after updating any these formula in this tap it's probably recommended to go ahead and rebuild this bottle to keep things working.

because right now the after building freecad on the macos runner provided by github and installing the bottled version of pyside6_py313, freecad is adding the wrong revision of the formula for pyside6_py313 so when freecadcmd goes to run the test suite, the following error message will occur.

```
======================================================================
ERROR: TestDraft (unittest.loader._FailedTest.TestDraft)
----------------------------------------------------------------------
ImportError: Failed to import test module: TestDraft
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.13_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/loader.py", line 137, in loadTestsFromName
    module = __import__(module_name)
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Draft/TestDraft.py", line 100, in <module>
    from drafttests.test_import import DraftImport as DraftTest01
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Draft/drafttests/test_import.py", line 37, in <module>
    from drafttests import auxiliary as aux
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Draft/drafttests/auxiliary.py", line 38, in <module>
    from draftutils.messages import _msg
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Draft/draftutils/messages.py", line 39, in <module>
    from draftutils import params
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Mod/Draft/draftutils/params.py", line 27, in <module>
    import PySide.QtCore as QtCore
  File "/opt/homebrew/Cellar/freecad@1.1.1_py313_qt6/1.1.1/Ext/PySide/__init__.py", line 2, in <module>
    from PySide6 import __version__
ModuleNotFoundError: No module named 'PySide6'
```

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
