### PR TITLE
pyside6_py313: update formula to use new pyside v6.11.1 to match upstream hbcore qt v6.11.1

### DIFF
--- a/Formula/pyside6_py313.rb
+++ b/Formula/pyside6_py313.rb
@@ -8,7 +8,7 @@ class Pyside6Py313 < Formula
   homepage "https://wiki.qt.io/Qt_for_Python"
   url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.11.1-src/pyside-setup-everywhere-src-6.11.1.tar.xz"
   mirror "https://cdimage.debian.org/mirror/qt.io/qtproject/official_releases/QtForPython/pyside6/PySide6-6.11.1-src/pyside-setup-everywhere-src-6.11.1.tar.xz"
-  sha256 "48d5c44d7c3ed861055d5491486e6a220ef5006573cae01a5fae3fb69d786336"
+  sha256 "6ffd9835bb0dd2c56f061d62f1616bb1707cfc0202b80e3165d6be087f3965e2"
   # NOTE: We omit some licenses even though they are in SPDX-License-Identifier or LICENSES/ directory:
   # 1. LicenseRef-Qt-Commercial is removed from "OR" options as non-free
   # 2. GFDL-1.3-no-invariants-only is only used by not installed docs, e.g. sources/{pyside6,shiboken6}/doc

--- a/Formula/pyside6_py313.rb
+++ b/Formula/pyside6_py313.rb
@@ -6,8 +6,8 @@ class Pyside6Py313 < Formula
 
   desc "Official Python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
-  url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.11.0-src/pyside-setup-everywhere-src-6.11.0.tar.xz"
-  mirror "https://cdimage.debian.org/mirror/qt.io/qtproject/official_releases/QtForPython/pyside6/PySide6-6.11.0-src/pyside-setup-everywhere-src-6.11.0.tar.xz"
+  url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.11.1-src/pyside-setup-everywhere-src-6.11.1.tar.xz"
+  mirror "https://cdimage.debian.org/mirror/qt.io/qtproject/official_releases/QtForPython/pyside6/PySide6-6.11.1-src/pyside-setup-everywhere-src-6.11.1.tar.xz"
   sha256 "48d5c44d7c3ed861055d5491486e6a220ef5006573cae01a5fae3fb69d786336"
   # NOTE: We omit some licenses even though they are in SPDX-License-Identifier or LICENSES/ directory:
   # 1. LicenseRef-Qt-Commercial is removed from "OR" options as non-free
@@ -18,7 +18,7 @@ class Pyside6Py313 < Formula
     { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } },
     { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
   ]
-  revision 2
+  revision 3
 
   livecheck do
     url "https://download.qt.io/official_releases/QtForPython/pyside6/"
@@ -242,10 +242,7 @@ class Pyside6Py313 < Formula
       4. it seems pyside v6.10 changed the install layout directory
       structure, thus the need for additional post install steps.
 
-      5. it seems pyside v6.10.2 can not be built against qt v6.10.2
-      without the above patching via sed (right now)
-
-      6. the arch package is useful for referencing to stay updated
+      5. the arch package is useful for referencing to stay updated
       https://gitlab.archlinux.org/archlinux/packaging/packages/pyside6
     EOS
   end


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [x] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
