### PR TITLE
fc_bundle_py313_qt6: update formula to install new dep defusedxml

### DIFF
--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -108,7 +108,7 @@ class FcBundlePy313Qt6 < Formula
     # Install the six module using pip in the virtual environment
     # certain freecad workbenches require the python six module
     # setup and install lark ply six
-    %w[lark ply six pyyaml typing-extensions].each do |pkg|
+    %w[defusedxml lark ply pyymal six typing-extensions].each do |pkg|
       resource(pkg).stage do
         system venv_pip, "install", "."
       end

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -10,7 +10,7 @@ class FcBundlePy313Qt6 < Formula
   version "1.1.1"
   # sha of file:///dev/null
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  revision 4
+  revision 5
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"
@@ -29,7 +29,7 @@ class FcBundlePy313Qt6 < Formula
   depends_on "geos"
   depends_on "libyaml"
   depends_on "numpy"
-  depends_on "pybind11" # reqd by pyyaml
+  depends_on "pybind11" # req'd by pyyaml
   depends_on "webp" if OS.linux?
   depends_on "zlib-ng-compat" if OS.linux?
 
@@ -50,6 +50,12 @@ class FcBundlePy313Qt6 < Formula
     end
   end
 
+  # NOTE: addon-manager now requires this python module / package
+  resource "defusedxml" do
+    url "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz"
+    sha256 "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+  end
+
   # NOTE: newer versions of the BIM wb require lark
   resource "lark" do
     url "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz"
@@ -61,17 +67,6 @@ class FcBundlePy313Qt6 < Formula
     sha256 "00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
   end
 
-  # NOTE: it appears it has been several years since the six pypi package has been updated
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
-    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
-  end
-
-  resource "shapely" do
-    url "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz"
-    sha256 "2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9"
-  end
-
   resource "pynastran" do
     url "https://github.com/SteveDoyle2/pyNastran/archive/refs/tags/v1.4.1.tar.gz"
     sha256 "445c4cd0ead937206ea743c0e2f9f743261fbc10891e26ec948a755f6b825df3"
@@ -81,6 +76,17 @@ class FcBundlePy313Qt6 < Formula
   resource "pyyaml" do
     url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
     sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "shapely" do
+    url "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz"
+    sha256 "2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9"
+  end
+
+  # NOTE: it appears it has been several years since the six pypi package has been updated
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
   end
 
   # NOTE: typing-extensions is req'd by BIM/Arch wb test suite

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -95,6 +95,8 @@ class FcBundlePy313Qt6 < Formula
     sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
   end
 
+  fails_with :gcc
+
   def install
     # explicitly set python version
     pyver = "3.13"
@@ -108,7 +110,7 @@ class FcBundlePy313Qt6 < Formula
     # Install the six module using pip in the virtual environment
     # certain freecad workbenches require the python six module
     # setup and install lark ply six
-    %w[defusedxml lark ply pyymal six typing-extensions].each do |pkg|
+    %w[defusedxml lark ply pyyaml six typing-extensions].each do |pkg|
       resource(pkg).stage do
         system venv_pip, "install", "."
       end

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -34,6 +34,8 @@ class FcBundlePy313Qt6 < Formula
   depends_on "zlib-ng-compat" if OS.linux?
 
   # NOTE: ipatch, https://docs.ifcopenshell.org/ifcopenshell-python/installation.html#zip-packages
+  fails_with :gcc
+
   resource "ifcopenshell" do
     if OS.mac? && Hardware::CPU.arm?
       url "https://github.com/IfcOpenShell/IfcOpenShell/releases/download/ifcopenshell-python-0.8.4/ifcopenshell-python-0.8.4-py313-macosm164.zip"
@@ -94,8 +96,6 @@ class FcBundlePy313Qt6 < Formula
     url "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
     sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
   end
-
-  fails_with :gcc
 
   def install
     # explicitly set python version


### PR DESCRIPTION
- **fc_bundle_py313_qt6: alphabetize resources and add new resource for addonmanager ie. defusedxml**
- **fc_bundle_py313_qt6: actually attempt to install the dep**
- **fc_bundle_py313_qt6: fix typo**
- **fc_bundle_py313_qt6: fix style error**

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
