### PR TITLE
[no ci] update tests.yml pre-create test suite dirs on macos due to sandboxing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -289,6 +289,23 @@ jobs:
         run: |
           brew install --formula python@3.14 python@3.13 python@3.12 || true
 
+      - name: pre-create FreeCAD dirs on macos to allow test suite to run
+        if: runner.os == 'macOS'
+        run: |
+          # FreeCAD's App::ApplicationDirectories::configurePaths() calls
+          # create_directories() on NSHomeDirectory()-derived paths during
+          # initConfig(). It ignores $HOME/FREECAD_USER_HOME, and the
+          # resulting filesystem_error escapes to main(), so any FreeCADCmd
+          # invocation aborts. Homebrew sandboxes build, test, and postinstall
+          # on macOS, so this cannot be done from the formula.
+          # TODO: file an upstream issue, ie. https://github.com/freecad/freecad/issues
+          # NOTE: the below variable will have to be defined / set more robustly
+          # due to new version scheme in the next freecad release ie. freecad v26.x
+          V=v1-1
+          mkdir -p ~/Library/Caches/FreeCAD/$V \
+                   ~/Library/Preferences/FreeCAD/$V \
+                   ~/Library/"Application Support"/FreeCAD/$V
+
       - name: build bottle using test-bot for current formula
         id: build-bottle
         env:


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
