### PR TITLE
freecad@1.1.3_py313_qt6: setup new formula for v1.1.3 release

### DIFF
--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -48,13 +48,6 @@ class FreecadAT113Py313Qt6 < Formula
     #   sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
     # end
 
-    # patch do
-    #   on_linux do
-    #     url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
-    #     sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
-    #   end
-    # end
-
     # NOTE: ipatch, building rc2 >= tags of freecad require resource blocks due to the use of git submodules
     resource "ondselsolver" do
       url "https://github.com/FreeCAD/OndselSolver/archive/30e9b64e8bf881d438d4b88834f9ba3674865418.tar.gz"
@@ -96,13 +89,6 @@ class FreecadAT113Py313Qt6 < Formula
     patch do
       url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
       sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
-    end
-
-    patch do
-      on_linux do
-        url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
-        sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
-      end
     end
   end
 

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -6,6 +6,10 @@ class FreecadAT113Py313Qt6 < Formula
   homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
+  # populate version info lost from tarball ie. because not .git dir
+  # NOTE: run the below 2 cmds in the git clone of the fc src dir
+  # 1. `git rev-parse --short 1.1.3` wcref
+  # 2. `git log -1 --format=%ci 1.1.3` wcdate
   PY_VER = "3.13".freeze
   VERSION_COMMIT_REF = "145529fe74".freeze
   VERSION_COMMIT_DATE = "2026-07-25 00:52:02 -0400".freeze
@@ -24,28 +28,11 @@ class FreecadAT113Py313Qt6 < Formula
     #   sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
     # end
 
-    # fix bld with pyside 6.11
-    # patch do
-    #   url "https://github.com/FreeCAD/FreeCAD/commit/1c599a2248.patch?full_index=1"
-    #   sha256 "e4895af708867eb45b4195f3e40eb330108a8fa8081aee5e2e17ff01f06d9f86"
-    # end
-
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983
     # patch do
     #   url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
     #   sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
-    # end
-
-    # fix bld with qt v6.11
-    # patch do
-    #   url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
-    #   sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
-    # end
-
-    # patch do
-    #   url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
-    #   sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
     # end
 
     # NOTE: ipatch, building rc2 >= tags of freecad require resource blocks due to the use of git submodules
@@ -79,12 +66,6 @@ class FreecadAT113Py313Qt6 < Formula
       url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
       sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
     end
-
-    # fix bld with qt v6.11
-    # patch do
-    #   url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
-    #   sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
-    # end
 
     patch do
       url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
@@ -345,6 +326,9 @@ class FreecadAT113Py313Qt6 < Formula
 
     ninja_bin = formula_opt_bin("ninja")/"ninja"
 
+    # bld err w/ 1.1.3 tarball due to SoFCOffscreenRenderer.cpp
+    ENV.append "CXXFLAGS", "-isystem #{Formula["mesa-glu"].include}"
+
     # NOTE: when build with PCL enabled recent versions of pcl have updated to "imported targets"
     ENV.append "CXXFLAGS", "-isystem #{Formula["flann"].include}"
 
@@ -418,10 +402,6 @@ class FreecadAT113Py313Qt6 < Formula
     args.concat(args_macos_only) if OS.mac?
     args.concat(args_linux_only) if OS.linux?
 
-    # populate version info lost from tarball ie. because not .git dir
-    # NOTE: run the below 2 cmds in the git clone of the fc src dir
-    # 1. `git rev-parse --short 1.1.3` wcref
-    # 2. `git log -1 --format=%ci 1.1.3` wcdate
     inreplace buildpath/"src/Build/Version.h.cmake" do |s|
       s.gsub!(/^(#define FCRevision\s+").*(".*$)/, "\\1#{VERSION_COMMIT_REF}\\2")
       s.gsub!(/^(#define FCRevisionDate\s+").*(".*$)/, "\\1#{VERSION_COMMIT_DATE}\\2")

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -23,10 +23,10 @@ class FreecadAT113Py313Qt6 < Formula
     #---
 
     # fix bld with cam/path wb failing test in test module, ie. test 46/47
-    # patch do
-    #   url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
-    #   sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
-    # end
+    patch do
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
+      sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
+    end
 
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983
@@ -59,6 +59,12 @@ class FreecadAT113Py313Qt6 < Formula
 
   head do
     url "https://github.com/freecad/FreeCAD.git", branch: "main", shallow: false
+
+    # fix bld with cam/path wb failing test in test module, ie. test 46/47
+    patch do
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
+      sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
+    end
 
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -409,7 +409,7 @@ class FreecadAT113Py313Qt6 < Formula
     end
 
     # TODO: probably requires a separate formula to post_install the freecad py module
-    #...or some sort of post install step
+    # ...or some sort of post install step
     args << "-DINSTALL_TO_SITEPACKAGES=OFF"
 
     # NOTE: useful cmake debugging args

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -1,26 +1,26 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # SPDX-FileNotice: Part of the FreeCAD project.
 
-class FreecadAT111Py313Qt6 < Formula
+class FreecadAT113Py313Qt6 < Formula
   desc "Parametric 3D modeler"
   homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
   stable do
-    url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/freecad_source_1.1.1.tar.gz"
-    sha256 "c0e95d41415f1e73bfe2e0a0a28210f649b01ef531bbfed1ed15863950dc5381"
+    url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.3/freecad_source_1.1.3.tar.gz"
+    sha256 "4813a5cd12be05253cd40cc1dc3995b1aaa1aa06f7dfbc15c7ffa99c1c3903b7"
 
     # fix bld with cam/path wb failing test in test module, ie. test 46/47
-    patch do
-      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
-      sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
-    end
+    # patch do
+    #   url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
+    #   sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
+    # end
 
     # fix bld with pyside 6.11
-    patch do
-      url "https://github.com/FreeCAD/FreeCAD/commit/1c599a2248.patch?full_index=1"
-      sha256 "e4895af708867eb45b4195f3e40eb330108a8fa8081aee5e2e17ff01f06d9f86"
-    end
+    # patch do
+    #   url "https://github.com/FreeCAD/FreeCAD/commit/1c599a2248.patch?full_index=1"
+    #   sha256 "e4895af708867eb45b4195f3e40eb330108a8fa8081aee5e2e17ff01f06d9f86"
+    # end
 
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983
@@ -30,21 +30,21 @@ class FreecadAT111Py313Qt6 < Formula
     end
 
     # fix bld with qt v6.11
-    patch do
-      url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
-      sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
-    end
+    # patch do
+    #   url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
+    #   sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
+    # end
 
-    patch do
-      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
-      sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
-    end
+    # patch do
+    #   url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
+    #   sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
+    # end
 
-    patch do
-      on_linux do
-        url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
-        sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
-      end
+    # patch do
+    #   on_linux do
+    #     url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
+    #     sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
+    #   end
     end
 
     # NOTE: ipatch, building rc2 >= tags of freecad require resource blocks due to the use of git submodules

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -30,10 +30,10 @@ class FreecadAT113Py313Qt6 < Formula
 
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983
-    # patch do
-    #   url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
-    #   sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
-    # end
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
+      sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
+    end
 
     # NOTE: ipatch, building rc2 >= tags of freecad require resource blocks due to the use of git submodules
     resource "ondselsolver" do

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -6,9 +6,17 @@ class FreecadAT113Py313Qt6 < Formula
   homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
+  PY_VER = "3.13".freeze
+  VERSION_COMMIT_REF = "145529fe74".freeze
+  VERSION_COMMIT_DATE = "2026-07-25 00:52:02 -0400".freeze
+
   stable do
     url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.3/freecad_source_1.1.3.tar.gz"
     sha256 "4813a5cd12be05253cd40cc1dc3995b1aaa1aa06f7dfbc15c7ffa99c1c3903b7"
+
+    # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`
+    # run `brew cleanup` when editing local patch files on each subsequent `brew install`
+    #---
 
     # fix bld with cam/path wb failing test in test module, ie. test 46/47
     # patch do
@@ -45,7 +53,7 @@ class FreecadAT113Py313Qt6 < Formula
     #     url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
     #     sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
     #   end
-    end
+    # end
 
     # NOTE: ipatch, building rc2 >= tags of freecad require resource blocks due to the use of git submodules
     resource "ondselsolver" do
@@ -62,25 +70,12 @@ class FreecadAT113Py313Qt6 < Formula
       url "https://github.com/microsoft/GSL/archive/refs/tags/v4.1.0.tar.gz"
       sha256 "0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd"
     end
+
+    resource "addonmanager" do
+      url "https://github.com/freecad/addonmanager/archive/937b6877239dc78ef59eeefe8099e5f14243eda1.tar.gz"
+      sha256 "70b2fa7f3c58c0ea5be830de90d33369670ee6658f13aeb7684f1ea478528178"
+    end
   end
-
-  bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    rebuild 2
-    sha256 cellar: :any, arm64_tahoe:   "34a8ba1f7cbb38493b658b08c45ff6cd81ee68eb91b4dcd907da4bcd2f511d64"
-    sha256 cellar: :any, arm64_sequoia: "3673828df08b287d0d0ff8efe2f243a6f5297e8073f40f7a2e9cf2e2568f0e36"
-    sha256 cellar: :any, arm64_sonoma:  "da36bb6702cd9c1b95f89052d5afad33cd30133a79f65c1588505f704fc24ebc"
-    sha256               arm64_linux:   "a58e96f815133cc9357c5c34653c423b5118e49cead32542bd437018a8d9b901"
-    sha256               x86_64_linux:  "7835b68259528a53b6eaad1c7e004edd96f31c8241393e7034c7fc133ffd3da4"
-  end
-
-  PY_VER = "3.13".freeze
-  VERSION_COMMIT_REF = "0108fd4b48".freeze
-  VERSION_COMMIT_DATE = "2026-04-14 19:09:59 -0300".freeze
-
-  # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`
-  # run `brew cleanup` when editing local patch files on each subsequent `brew install`
-  #---
 
   head do
     url "https://github.com/freecad/FreeCAD.git", branch: "main", shallow: false
@@ -93,10 +88,10 @@ class FreecadAT113Py313Qt6 < Formula
     end
 
     # fix bld with qt v6.11
-    patch do
-      url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
-      sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
-    end
+    # patch do
+    #   url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
+    #   sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
+    # end
 
     patch do
       url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
@@ -194,7 +189,7 @@ class FreecadAT113Py313Qt6 < Formula
     puts "PYTHON_INCLUDE_DIR=#{py_inc_dir}"
     puts "PYTHON_LIBRARY=#{py_lib_path}"
 
-    # NOTE: apple's clang & clang++ don not provide batteries for open-mpi
+    # NOTE: apple's clang & clang++ do not provide batteries for open-mpi
     # NOTE: when setting the compilers to brews' llvm, set the cmake_ar linker as well
     # ENV["CC"] = Formula["llvm"].opt_bin/"clang"
     # ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
@@ -413,9 +408,8 @@ class FreecadAT113Py313Qt6 < Formula
       args << "-DQT_ADDITIONAL_PACKAGES_PREFIX_PATH=#{qt_module_prefixes.join(";")}"
     end
 
-    args << "--debug-find-pkg=VTK"
-
     # TODO: probably requires a separate formula to post_install the freecad py module
+    #...or some sort of post install step
     args << "-DINSTALL_TO_SITEPACKAGES=OFF"
 
     # NOTE: useful cmake debugging args
@@ -433,14 +427,15 @@ class FreecadAT113Py313Qt6 < Formula
     resource("googletest").stage(buildpath/"tests/lib")
     resource("msgsl").stage(buildpath/"src/3rdParty/GSL")
     resource("ondselsolver").stage(buildpath/"src/3rdParty/OndselSolver")
+    resource("addonmanager").stage(buildpath/"src/3rdParty/AddonManager")
 
     args.concat(args_macos_only) if OS.mac?
     args.concat(args_linux_only) if OS.linux?
 
     # populate version info lost from tarball ie. because not .git dir
     # NOTE: run the below 2 cmds in the git clone of the fc src dir
-    # 1. `git rev-parse --short 1.1.0` wcref
-    # 2. `git log -1 --format=%ci 1.1.0` wcdate
+    # 1. `git rev-parse --short 1.1.3` wcref
+    # 2. `git log -1 --format=%ci 1.1.3` wcdate
     inreplace buildpath/"src/Build/Version.h.cmake" do |s|
       s.gsub!(/^(#define FCRevision\s+").*(".*$)/, "\\1#{VERSION_COMMIT_REF}\\2")
       s.gsub!(/^(#define FCRevisionDate\s+").*(".*$)/, "\\1#{VERSION_COMMIT_DATE}\\2")

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -32,10 +32,10 @@ class FreecadAT113Py313Qt6 < Formula
 
     # fix bld with macos 26 and explicit template arugments
     # https://github.com/FreeCAD/FreeCAD/issues/28983
-    patch do
-      url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
-      sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
-    end
+    # patch do
+    #   url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
+    #   sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
+    # end
 
     # fix bld with qt v6.11
     # patch do

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -1,0 +1,575 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+class FreecadAT111Py313Qt6 < Formula
+  desc "Parametric 3D modeler"
+  homepage "https://freecad.org/"
+  license "GPL-2.0-only"
+
+  stable do
+    url "https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/freecad_source_1.1.1.tar.gz"
+    sha256 "c0e95d41415f1e73bfe2e0a0a28210f649b01ef531bbfed1ed15863950dc5381"
+
+    # fix bld with cam/path wb failing test in test module, ie. test 46/47
+    patch do
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/75d7aeadfc17a28e7830342bce876fd51cf84d79/patches/freecad%401.1.1_py313_qt6-fix-cam-failing-tests.patch?full_index=1"
+      sha256 "0e4821678fa2dc0468a88af0528cf8e6fbf96e9c56aff6ea9937ec043745d3b3"
+    end
+
+    # fix bld with pyside 6.11
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/1c599a2248.patch?full_index=1"
+      sha256 "e4895af708867eb45b4195f3e40eb330108a8fa8081aee5e2e17ff01f06d9f86"
+    end
+
+    # fix bld with macos 26 and explicit template arugments
+    # https://github.com/FreeCAD/FreeCAD/issues/28983
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
+      sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
+    end
+
+    # fix bld with qt v6.11
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
+      sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
+      sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
+    end
+
+    patch do
+      on_linux do
+        url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
+        sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
+      end
+    end
+
+    # NOTE: ipatch, building rc2 >= tags of freecad require resource blocks due to the use of git submodules
+    resource "ondselsolver" do
+      url "https://github.com/FreeCAD/OndselSolver/archive/30e9b64e8bf881d438d4b88834f9ba3674865418.tar.gz"
+      sha256 "77646ca7d8cbc6dc4e8304439be2ff2b9aecf397e6349e63b3b06e65dfed79c3"
+    end
+
+    resource "googletest" do
+      url "https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"
+      sha256 "7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926"
+    end
+
+    resource "msgsl" do
+      url "https://github.com/microsoft/GSL/archive/refs/tags/v4.1.0.tar.gz"
+      sha256 "0a227fc9c8e0bf25115f401b9a46c2a68cd28f299d24ab195284eb3f1d7794bd"
+    end
+  end
+
+  bottle do
+    root_url "https://ghcr.io/v2/freecad/freecad"
+    rebuild 2
+    sha256 cellar: :any, arm64_tahoe:   "34a8ba1f7cbb38493b658b08c45ff6cd81ee68eb91b4dcd907da4bcd2f511d64"
+    sha256 cellar: :any, arm64_sequoia: "3673828df08b287d0d0ff8efe2f243a6f5297e8073f40f7a2e9cf2e2568f0e36"
+    sha256 cellar: :any, arm64_sonoma:  "da36bb6702cd9c1b95f89052d5afad33cd30133a79f65c1588505f704fc24ebc"
+    sha256               arm64_linux:   "a58e96f815133cc9357c5c34653c423b5118e49cead32542bd437018a8d9b901"
+    sha256               x86_64_linux:  "7835b68259528a53b6eaad1c7e004edd96f31c8241393e7034c7fc133ffd3da4"
+  end
+
+  PY_VER = "3.13".freeze
+  VERSION_COMMIT_REF = "0108fd4b48".freeze
+  VERSION_COMMIT_DATE = "2026-04-14 19:09:59 -0300".freeze
+
+  # NOTE: ipatch, ie. local patch `url "file:///#{HOMEBREW_PREFIX}/Library/Taps/freecad/homebrew-freecad/patches/`
+  # run `brew cleanup` when editing local patch files on each subsequent `brew install`
+  #---
+
+  head do
+    url "https://github.com/freecad/FreeCAD.git", branch: "main", shallow: false
+
+    # fix bld with macos 26 and explicit template arugments
+    # https://github.com/FreeCAD/FreeCAD/issues/28983
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/7c57a764ccd8258fa6bc2b5dfbcead00976c0e94.patch?full_index=1"
+      sha256 "0a1a00cdbe96eac06ed757c69b23225632d036d97dd472410e04e8736bd6547d"
+    end
+
+    # fix bld with qt v6.11
+    patch do
+      url "https://github.com/FreeCAD/FreeCAD/commit/3afc58c6be7a6441e91bf474755edf78880beb1f.patch?full_index=1"
+      sha256 "0dc578332bb051d259d77773362f3d6e0daf7be9c764cc3e6d6adf29f4658a93"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/1fde4f693950d77e8617c08921d50c1aba3f0a56/patches/freecad-0.20.2-cmake-find-xercesc.patch"
+      sha256 "adb30f5d723672d1d54db4a236bce8a85e9bc9d0667ef88a7360e4cae1bb27c9"
+    end
+
+    patch do
+      on_linux do
+        url "https://raw.githubusercontent.com/FreeCAD/homebrew-freecad/0e3bdef3b239a1f81e07bf774ae799819f3cea90/patches/freecad%401.0.0_py312-linuxbrew-fix-missing-headers.patch"
+        sha256 "7c7e0376e676096d32bbf05e23ab10556e50ef54effff7777d325bda490dde11"
+      end
+    end
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "gcc" => :build # gfortran req for FEM WB
+  depends_on "lld" => :build if OS.linux?
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "swig" => :build
+  depends_on "boost"
+  depends_on "cups" # qt6
+  depends_on "cython"
+  depends_on "doxygen"
+  depends_on "expat"
+  depends_on "flann"
+  depends_on "fmt"
+  depends_on "fontconfig" if OS.linux?
+  depends_on "freecad/freecad/calculix@2.23"
+  depends_on "freecad/freecad/coin3d@4.0.8_py313_qt6"
+  depends_on "freecad/freecad/fc_bundle_py313_qt6"
+  depends_on "freecad/freecad/med-file@5.0.0_py313"
+  depends_on "freecad/freecad/netgen@6.2.2601" # uses py313
+  depends_on "freecad/freecad/pyside6_py313"
+  depends_on "freecad/freecad/vtk@9.5.2_py313"
+  depends_on "freeimage"
+  depends_on "freetype"
+  depends_on "glew"
+  depends_on "hdf5"
+  depends_on "icu4c"
+  depends_on "icu4c@78" # because macos-15 bld err
+  depends_on "libaec"
+  depends_on "libomp"
+  depends_on "libx11" if OS.linux?
+  depends_on "llvm" if OS.linux?
+  depends_on "mesa" if OS.linux?
+  depends_on "mesa-glu" if OS.linux?
+  depends_on "nlohmann-json"
+  depends_on "numpy"
+  depends_on "open-mpi" if OS.linux?
+  depends_on "openblas" if OS.linux?
+  depends_on "opencascade"
+  depends_on "orocos-kdl"
+  depends_on "pcl"
+  depends_on "pybind11"
+  depends_on "python@3.13"
+  depends_on "qt"
+  depends_on "qtbase"
+  depends_on "qtsvg"
+  depends_on "qttools"
+  depends_on "tbb"
+  depends_on "vtk"
+  depends_on "vulkan-headers"
+  depends_on "webp"
+  depends_on "xerces-c"
+  depends_on "yaml-cpp"
+  depends_on "zlib-ng-compat"
+  on_macos do
+    depends_on macos: :ventura # because qt v6
+  end
+
+  def install
+    hbp = HOMEBREW_PREFIX
+
+    # NOTE: `which` cmd is not installed by default on every OS
+    # ENV["PYTHON"] = which("python3.10")
+    #------------
+    ENV["PYTHON"] = formula_opt_bin("python@#{PY_VER}")/"python#{PY_VER}"
+
+    # Get the Python includes directory without duplicates
+    py_inc_output = `python#{PY_VER}-config --includes`
+    py_inc_dirs = py_inc_output.scan(/-I([^\s]+)/).flatten.uniq
+    py_inc_dir = py_inc_dirs.join(" ")
+
+    py_lib_path = if OS.mac?
+      `python#{PY_VER}-config --configdir`.strip + "/libpython#{PY_VER}.dylib"
+    else
+      `python#{PY_VER}-config --configdir`.strip + "/libpython#{PY_VER}.a"
+    end
+
+    puts "----------------------------------------------------"
+    puts "PYTHON=#{ENV["PYTHON"]}"
+    puts "PYTHON_INCLUDE_DIR=#{py_inc_dir}"
+    puts "PYTHON_LIBRARY=#{py_lib_path}"
+
+    # NOTE: apple's clang & clang++ don not provide batteries for open-mpi
+    # NOTE: when setting the compilers to brews' llvm, set the cmake_ar linker as well
+    # ENV["CC"] = Formula["llvm"].opt_bin/"clang"
+    # ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
+
+    ENV.delete("CMAKE_PREFIX_PATH") # Clear existing paths
+    puts "----------------------------------------------------"
+    puts "CMAKE_PREFIX_PATH=#{ENV["CMAKE_PREFIX_PATH"]}"
+    puts "CMAKE_PREFIX_PATH Datatype: #{ENV["CMAKE_PREFIX_PATH"].class}"
+    puts "----------------------------------------------------"
+    puts "homebrew prefix: #{hbp}"
+    puts "prefix: #{prefix}"
+    puts "rpath: #{rpath}"
+
+    ENV.remove "PATH", formula_opt_prefix("qt@5")/"bin"
+    puts "PATH=#{ENV["PATH"]}"
+
+    cmake_prefix_paths = []
+    # cmake_prefix_paths << Formula["llvm"].prefix
+    cmake_prefix_paths << Formula["boost"].prefix
+    cmake_prefix_paths << Formula["calculix@2.23"].prefix
+    cmake_prefix_paths << Formula["coin3d@4.0.8_py313_qt6"].prefix
+    cmake_prefix_paths << Formula["cups"].prefix
+    cmake_prefix_paths << Formula["double-conversion"].prefix
+    cmake_prefix_paths << Formula["doxygen"].prefix
+    cmake_prefix_paths << Formula["eigen"].prefix
+    cmake_prefix_paths << Formula["expat"].prefix
+    cmake_prefix_paths << Formula["flann"].prefix
+    cmake_prefix_paths << Formula["fmt"].prefix
+    cmake_prefix_paths << Formula["freeimage"].prefix
+    cmake_prefix_paths << Formula["freetype"].prefix
+    cmake_prefix_paths << Formula["glew"].prefix
+    cmake_prefix_paths << Formula["hdf5"].prefix
+    cmake_prefix_paths << Formula["icu4c"].prefix
+    cmake_prefix_paths << Formula["libjpeg-turbo"].prefix
+    cmake_prefix_paths << Formula["libaec"].prefix
+    cmake_prefix_paths << Formula["libomp"].prefix
+    cmake_prefix_paths << Formula["libpng"].prefix
+    cmake_prefix_paths << Formula["libtiff"].prefix
+    cmake_prefix_paths << Formula["lz4"].prefix
+    cmake_prefix_paths << Formula["med-file@5.0.0_py313"].prefix
+    cmake_prefix_paths << Formula["netgen@6.2.2601"].prefix
+    cmake_prefix_paths << Formula["nlohmann-json"].prefix
+    cmake_prefix_paths << Formula["opencascade"].prefix
+    cmake_prefix_paths << Formula["orocos-kdl"].prefix
+    cmake_prefix_paths << Formula["pcl"].prefix
+    cmake_prefix_paths << Formula["pkg-config"].prefix
+    cmake_prefix_paths << Formula["pugixml"].prefix
+    cmake_prefix_paths << Formula["pybind11"].prefix
+    cmake_prefix_paths << Formula["pyside6_py313"].prefix
+    cmake_prefix_paths << Formula["qt"].prefix
+    cmake_prefix_paths << Formula["qtbase"].prefix
+    cmake_prefix_paths << Formula["qtsvg"].prefix
+    cmake_prefix_paths << Formula["qttools"].prefix
+    cmake_prefix_paths << Formula["swig"].prefix
+    cmake_prefix_paths << Formula["tbb"].prefix
+    cmake_prefix_paths << Formula["utf8cpp"].prefix
+    cmake_prefix_paths << Formula["vulkan-headers"].prefix
+    cmake_prefix_paths << Formula["vtk@9.5.2_py313"].prefix
+    cmake_prefix_paths << Formula["xerces-c"].prefix
+    cmake_prefix_paths << Formula["xz"].prefix
+    cmake_prefix_paths << Formula["yaml-cpp"].prefix
+    cmake_prefix_paths << Formula["zlib-ng-compat"].prefix
+
+    if OS.linux?
+      cmake_prefix_paths << Formula["fontconfig"].prefix
+      cmake_prefix_paths << Formula["libx11"].prefix
+      cmake_prefix_paths << Formula["libxcb"].prefix
+      cmake_prefix_paths << Formula["llvm"].prefix
+      cmake_prefix_paths << Formula["mesa"].prefix
+      cmake_prefix_paths << Formula["mesa-glu"].prefix
+      cmake_prefix_paths << Formula["openblas"].prefix
+      cmake_prefix_paths << Formula["open-mpi"].prefix
+    end
+
+    cmake_prefix_path_string = cmake_prefix_paths.join(";")
+
+    # Check if Xcode.app exists
+    if File.directory?("/Applications/Xcode.app")
+      apl_sdk = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+      apl_frmwks ="#{apl_sdk}/System/Library/Frameworks"
+      cmake_ar = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar"
+      cmake_ld = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld"
+
+    else
+      apl_sdk = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      apl_frmwks = "#{apl_sdk}/System/Library/Frameworks"
+      cmake_ar = "/Library/Developer/CommandLineTools/usr/bin/ar"
+      cmake_ld = "/Library/Developer/CommandLineTools/usr/bin/ld"
+    end
+
+    # NOTE: the below cmake vars can be stubbed out ie. set
+    # -DCMAKE_OSX_SYSROOT=#{cmake_osx_sysroot}
+    # -DCMAKE_CXX_FLAGS="-fuse-ld=lld"
+    # -DBUILD_ENABLE_CXX_STD=C++17 # freecad v1.1.0 now reqs C++20
+    # -DCMAKE_INSTALL_RPATH=#{prefix}/lib
+    # -DCMAKE_INSTALL_RPATH=#{rpath}
+    # -DBUILD_DRAWING=1
+    # -DBUILD_SMESH=1
+    # -DFREECAD_USE_QTWEBMODULE=#{qtwebmodule}
+    # -DCMAKE_EXE_LINKER_FLAGS="-v"
+    # -DCCACHE_PROGRAM:FILEPATH=CCACHE_PROGRAM-NOTFOUND
+    # -DFREECAD_PARALLEL_COMPILE_JOBS:BOOL=OFF
+    # -DFREECAD_PARALLEL_LINK_JOBS:BOOL=OFF
+
+    if OS.mac?
+      arch = Hardware::CPU.arch.to_s
+      fver = OS::Mac.full_version.to_s
+
+      args_macos_only = %W[
+        -DCMAKE_OSX_ARCHITECTURES=#{arch}
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=#{fver}
+        -DCMAKE_AR=#{cmake_ar}
+        -DCMAKE_LINKER=#{cmake_ld}
+        -DCMAKE_INSTALL_NAME_TOOL:FILEPATH=/usr/bin/install_name_tool
+        -DOPENGL_INCLUDE_DIR=#{apl_frmwks}/OpenGL.framework
+        -DOPENGL_gl_LIBRARY=#{apl_frmwks}/OpenGL.framework
+        -DOPENGL_GLU_INCLUDE_DIR=#{apl_frmwks}/OpenGL.framework
+        -DOPENGL_glu_LIBRARY=#{apl_frmwks}/OpenGL.framework
+        -DCOREFOUNDATION_LIBRARY=#{apl_frmwks}/CoreFoundation.framework
+        -DCMAKE_IGNORE_PATH=#{hbp}/Cellar/qt@5;#{hbp}/opt/qt@5;
+
+        -DNetgen_DIR=#{formula_opt_prefix("netgen@6.2.2601")}/Contents/Resources/CMake
+      ]
+    end
+
+    if OS.linux?
+      clang_cc = formula_opt_bin("llvm")/"clang"
+      clang_cxx = formula_opt_bin("llvm")/"clang++"
+      clang_ld = formula_opt_bin("lld")/"lld"
+      clang_ar = formula_opt_bin("llvm")/"llvm-ar"
+
+      openglu_inc_dir = formula_opt_include("mesa-glu")
+
+      puts "----------------------------------------------------"
+      puts openglu_inc_dir
+      puts "----------------------------------------------------"
+
+      # NOTE: ipatch, linker req because, https://github.com/FreeCAD/homebrew-freecad/issues/546
+      linux_linker_flags = "-L#{HOMEBREW_PREFIX}/opt/gcc/lib/gcc/current " \
+                           "-Wl,-rpath,#{HOMEBREW_PREFIX}/opt/gcc/lib/gcc/current " \
+                           "-L#{formula_opt_lib("tbb")} -ltbb " \
+                           "-fuse-ld=lld"
+
+      # NOTE: these are keg-only formula thus their libs do not exist in #{hbp}/lib
+      # ... thus causing rpath issues on *nix based systems
+      coin_lib = formula_opt_lib("coin3d@4.0.8_py313_qt6")
+      libomp_lib = formula_opt_lib("libomp")
+      med_lib = formula_opt_lib("med-file@5.0.0_py313")
+      netgen_lib = formula_opt_lib("netgen@6.2.2601")
+      pyside6_lib = formula_opt_lib("pyside6_py313")
+      vtk_lib = formula_opt_lib("vtk@9.5.2_py313")
+
+      args_linux_only = %W[
+        -DX11_X11_INCLUDE_PATH=#{hbp}/opt/libx11/include/X11
+        -DCMAKE_C_COMPILER=#{clang_cc}
+        -DCMAKE_CXX_COMPILER=#{clang_cxx}
+        -DCMAKE_LINKER=#{clang_ld}
+        -DCMAKE_AR=#{clang_ar}
+        -DOPENGL_GLU_INCLUDE_DIR=#{openglu_inc_dir}
+        -DCMAKE_EXE_LINKER_FLAGS=#{linux_linker_flags}
+        -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld
+        -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld
+        -DCMAKE_INSTALL_RPATH=#{hbp}/lib;#{coin_lib};#{libomp_lib};#{med_lib};#{netgen_lib};#{pyside6_lib};#{vtk_lib}
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+      ]
+    end
+
+    ninja_bin = formula_opt_bin("ninja")/"ninja"
+
+    # NOTE: when build with PCL enabled recent versions of pcl have updated to "imported targets"
+    ENV.append "CXXFLAGS", "-isystem #{Formula["flann"].include}"
+
+    # NOTE: tbb circa aug 2026 is giving missing header error ie. blocked_range.h
+    ENV.append "CXXFLAGS", "-isystem #{Formula["tbb"].include}"
+
+    args = %W[
+      -DHOMEBREW_PREFIX=#{hbp}
+      -DCMAKE_PREFIX_PATH=#{cmake_prefix_path_string}
+      -DCMAKE_INSTALL_PREFIX=#{prefix}
+      -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+      -GNinja
+      -DCMAKE_MAKE_PROGRAM=#{ninja_bin}
+
+      -DPython_EXECUTABLE=#{ENV["PYTHON"]}
+      -DPython_INCLUDE_DIRS=#{py_inc_dir}
+      -DPython_LIBRARIES=#{py_lib_path}
+
+      -DPython3_EXECUTABLE=#{ENV["PYTHON"]}
+      -DPython3_INCLUDE_DIRS=#{py_inc_dir}
+      -DPython3_LIBRARIES=#{py_lib_path}
+
+      -DFREECAD_QT_VERSION=6
+      -DFREECAD_USE_PYBIND11:BOOL=ON
+      -DFREECAD_USE_EXTERNAL_KDL:BOOL=ON
+      -DBUILD_FEM_NETGEN=:BOOL=ON
+      -DFREECAD_LIBPACK_USE:BOOL=OFF
+      -DBUILD_WITH_CONDA:BOOL=OFF
+
+      -DFREECAD_USE_PCL:BOOL=ON
+      -DVTK_DIR=#{formula_opt_lib("freecad/freecad/vtk@9.5.2_py313")}/cmake/vtk-9.5
+
+      -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=FALSE
+      -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=FALSE
+
+      -DCMAKE_IGNORE_PATH=#{hbp}/Cellar/qt@5;#{hbp}/opt/qt@5;/lib64;/usr/lib64;
+
+      -L
+    ]
+
+    # NOTE: ipatch, the below vars were required to get cmake to configure freecad on ubuntu 22.04
+    if OS.linux? && File.exist?("/etc/os-release") &&
+       File.read("/etc/os-release").include?('VERSION_ID="22.04"')
+      qt_module_prefixes = %w[qtsvg qttools qtbase].map { |f| formula_opt_prefix(f) }
+      args << "-DQT_ADDITIONAL_PACKAGES_PREFIX_PATH=#{qt_module_prefixes.join(";")}"
+    end
+
+    args << "--debug-find-pkg=VTK"
+
+    # TODO: probably requires a separate formula to post_install the freecad py module
+    args << "-DINSTALL_TO_SITEPACKAGES=OFF"
+
+    # NOTE: useful cmake debugging args
+    # --trace
+    # -L
+
+    ENV.remove "PKG_CONFIG_PATH", formula_opt_prefix("qt@5")/"lib/pkgconfig"
+
+    ENV.remove "CMAKE_FRAMEWORK_PATH", formula_opt_prefix("qt@5")/"Frameworks"
+
+    ENV.remove "HOMEBREW_INCLUDE_PATHS", formula_opt_prefix("qt@5")/"include"
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", formula_opt_prefix("qt@5")/"lib"
+
+    # NOTE: resources have to be in the correct buildpath
+    resource("googletest").stage(buildpath/"tests/lib")
+    resource("msgsl").stage(buildpath/"src/3rdParty/GSL")
+    resource("ondselsolver").stage(buildpath/"src/3rdParty/OndselSolver")
+
+    args.concat(args_macos_only) if OS.mac?
+    args.concat(args_linux_only) if OS.linux?
+
+    # populate version info lost from tarball ie. because not .git dir
+    # NOTE: run the below 2 cmds in the git clone of the fc src dir
+    # 1. `git rev-parse --short 1.1.0` wcref
+    # 2. `git log -1 --format=%ci 1.1.0` wcdate
+    inreplace buildpath/"src/Build/Version.h.cmake" do |s|
+      s.gsub!(/^(#define FCRevision\s+").*(".*$)/, "\\1#{VERSION_COMMIT_REF}\\2")
+      s.gsub!(/^(#define FCRevisionDate\s+").*(".*$)/, "\\1#{VERSION_COMMIT_DATE}\\2")
+      s.gsub!(/^(#define FCRepositoryURL\s+").*(".*$)/, "\\1https://github.com/FreeCAD/FreeCAD\\2")
+    end
+
+    # NOTE: macos 14 does not fully support C++20 extension of CTAD
+    # ... https://developer.apple.com/xcode/cpp/
+    inreplace buildpath/"src/Gui/StyleParameters/ParameterManager.h",
+          "static inline const Gui::StyleParameters::ParameterDefinition _name_ \\",
+          "static inline const Gui::StyleParameters::ParameterDefinition<decltype(_defaultValue_)> _name_ \\"
+
+    inreplace buildpath/"src/Gui/StyleParameters/ParameterManager.h",
+            "    /// Numeric value of the length.\n    " \
+            "double value;",
+            "    /// Numeric value of the length.\n    " \
+            "double value;\n\n    " \
+            "Numeric() = default;\n    " \
+            "Numeric(double v, std::string u = \"\") " \
+            ": value(v), unit(std::move(u)) {}"
+
+    inreplace buildpath/"src/Mod/Import/App/dxf/ImpExpDxf.h",
+            "        // The raw geometric shape.\n        " \
+            "TopoDS_Shape shape;",
+            "        // The raw geometric shape.\n        " \
+            "TopoDS_Shape shape;\n\n        " \
+            "GeometryBuilder() = default;\n        " \
+            "explicit GeometryBuilder(const TopoDS_Shape& s, " \
+            "PrimitiveType t = PrimitiveType::None) : shape(s), type(t) {}"
+
+    inreplace buildpath/"src/Mod/Import/App/dxf/ImpExpDxf.h",
+            "GeometryBuilder(shape)",
+            "GeometryBuilder{shape}"
+
+    # debug, verify fix applied
+    puts "----------------------------------------------------"
+    if File.read(buildpath/"src/Gui/StyleParameters/ParameterManager.h").include?("decltype(_defaultValue_)")
+      puts "CTAD decltype fix: APPLIED"
+    else
+      puts "CTAD decltype fix: FAILED TO APPLY"
+    end
+    puts "----------------------------------------------------"
+
+    # NOTE: avoid in source builds
+    puts "current working directory: #{Dir.pwd}"
+    build_dir = buildpath/"build"
+    # Create the build directory if it doesn't exist
+    mkdir_p(build_dir)
+    # Change the working directory to the build directory
+    cd build_dir do
+      puts "----------------------------------------------------"
+      puts Dir.pwd
+      puts "Buildpath is: #{buildpath}"
+      puts "----------------------------------------------------"
+
+      system "cmake", *args, buildpath.to_s
+      system "cmake", "--build", "."
+      system "cmake", "--install", "."
+    end
+  end
+
+  def post_install
+    ohai "the value of prefix = #{prefix}"
+
+    # mac bundle drops FreeCAD's PySide shim in MacOS/; FreeCAD's sys.path
+    # expects it in Ext/ (as on Linux). Relocate so `import PySide` resolves.
+    if OS.mac? && (prefix/"MacOS/PySide").exist?
+      (prefix/"Ext/PySide").dirname.mkpath
+      mv prefix/"MacOS/PySide", prefix/"Ext/PySide"
+    end
+
+    if OS.mac?
+      ln_s "#{prefix}/MacOS/FreeCAD", "#{HOMEBREW_PREFIX}/bin/freecad", force: true
+      ln_s "#{prefix}/MacOS/FreeCADCmd", "#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
+    elsif OS.linux?
+      ln_s "#{bin}/FreeCAD", "#{HOMEBREW_PREFIX}/bin/freecad", force: true
+      ln_s "#{bin}/FreeCADCmd", "#{HOMEBREW_PREFIX}/bin/freecadcmd", force: true
+    end
+  end
+
+  def caveats
+    <<-EOS
+    After installing FreeCAD you may want to do the following:
+
+    1. Due to recent code signing updates with Catalina and newer
+       building a FreeCAD.app bundle using the existing python
+       script no longer works due to updating the rpaths of the
+       copied executables and libraries into a FreeCAD.app
+       bundle, unless performing a work around described in the
+       below github issue comment,
+       https://github.com/FreeCAD/homebrew-freecad/issues/348#issuecomment-1248927545
+
+    2. presently the freecad py module is NOT globally accessible, ie.
+       one cannot directly run `import freecad` from a python v#{PY_VER}
+       repl
+
+    3. if multiple versions of freecad are installed then the post install
+       step may fail, thus manual linking may be required to put this
+       version of freecad in #{HOMEBREW_PREFIX}/bin
+    EOS
+  end
+
+  test do
+    freecadcmd = OS.mac? ? prefix/"MacOS/FreeCADCmd" : bin/"FreeCADCmd"
+    if OS.mac?
+      # FreeCAD's App::ApplicationDirectories::configurePaths() calls
+      # create_directories() on NSHomeDirectory()-derived paths during
+      # initConfig(). NSHomeDirectory() resolves via getpwuid(), so neither
+      # $HOME nor FREECAD_USER_HOME/_USER_DATA/_USER_TEMP redirect it, and a
+      # filesystem_error there escapes to main() -- FreeCAD then reports only
+      # "Unknown runtime error occurred while initializing FreeCAD".
+      #
+      # Homebrew sandboxes build, test and postinstall on macOS, so those
+      # directories cannot be created from this formula. CI pre-creates them
+      # (see the "Pre-create FreeCAD state dirs" step in tests.yml).
+      # Running `brew test` locally on a machine that has never run FreeCAD
+      # will fail until upstream stops treating that failure as fatal.
+      # TODO: file an upstream issue, and possibly a PR that fixes the issue.
+      with_env("FREECAD_USER_HOME" => testpath.to_s, "TMPDIR" => testpath.to_s) do
+        system freecadcmd, "-t", "0"
+      end
+    else
+      with_env(
+        "FREECAD_USER_HOME" => testpath.to_s,
+        "FREECAD_USER_DATA" => testpath.to_s,
+        "FREECAD_USER_TEMP" => testpath.to_s,
+      ) do
+        system freecadcmd, "-t", "0"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- **freecad@1.1.1_py313_qt6: cp existing freecad@1.1.1_py313_qt6 formula to freecad@1.1.3_py313_qt6**
- **freecad@1.1.3_py313_qt6: comment out stable patches (for now) update class name**
- **freecad@1.1.3_py313_qt6: walk through formula update values needing change**
- **freecad@1.1.3_py313_qt6: run brew style on tap**
- **freecad@1.1.3_py313_qt6: comment out macos 26 specific patch**
- **freecad@1.1.3_py313_qt6: rm ref to linux only patch file, will not apply cleanly with 1.1.3 tarball**
- **freecad@1.1.3_py313_qt6: add note about add mesa-glu to cxx flags, rm erronous patch file refs reorg some comments**

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
