### PR TITLE
hbfc tap maintenance

### DIFF
--- a/Aliases/freecad
+++ b/Aliases/freecad
@@ -1,1 +1,1 @@
-../Formula/freecad@1.1.1_py313_qt6.rb
+../Formula/freecad@1.1.3_py313_qt6.rb

--- a/Formula/freecad@1.1.3_py313_qt6.rb
+++ b/Formula/freecad@1.1.3_py313_qt6.rb
@@ -6,15 +6,6 @@ class FreecadAT113Py313Qt6 < Formula
   homepage "https://freecad.org/"
   license "GPL-2.0-only"
 
-  bottle do
-    root_url "https://ghcr.io/v2/freecad/freecad"
-    sha256 cellar: :any, arm64_tahoe:   "7b3dfce7b133a9f68e57b1bc633bd07c58329c659b13416417af33118bcc8fb0"
-    sha256 cellar: :any, arm64_sequoia: "a861cf79a83fe9b9832091f3ace76b2e5d64418a2609242bc7fbfe3ceb4ad9b9"
-    sha256 cellar: :any, arm64_sonoma:  "0fe29cc647f26c739425c3cd01cac7454e0f7415a5c37e4dce67a0f9f0b77b96"
-    sha256               arm64_linux:   "5a4ec2946d48ba4bf3a08bb6bfdce28a4dd52d57f0860e17a1754e847c8c88b3"
-    sha256               x86_64_linux:  "aa7c257dc2a7e517572e6b588c3c205a05171aab45b17047571ebf76c85a5080"
-  end
-
   # populate version info lost from tarball ie. because not .git dir
   # NOTE: run the below 2 cmds in the git clone of the fc src dir
   # 1. `git rev-parse --short 1.1.3` wcref
@@ -64,6 +55,15 @@ class FreecadAT113Py313Qt6 < Formula
       url "https://github.com/freecad/addonmanager/archive/937b6877239dc78ef59eeefe8099e5f14243eda1.tar.gz"
       sha256 "70b2fa7f3c58c0ea5be830de90d33369670ee6658f13aeb7684f1ea478528178"
     end
+  end
+
+  bottle do
+    root_url "https://ghcr.io/v2/freecad/freecad"
+    sha256 cellar: :any, arm64_tahoe:   "7b3dfce7b133a9f68e57b1bc633bd07c58329c659b13416417af33118bcc8fb0"
+    sha256 cellar: :any, arm64_sequoia: "a861cf79a83fe9b9832091f3ace76b2e5d64418a2609242bc7fbfe3ceb4ad9b9"
+    sha256 cellar: :any, arm64_sonoma:  "0fe29cc647f26c739425c3cd01cac7454e0f7415a5c37e4dce67a0f9f0b77b96"
+    sha256               arm64_linux:   "5a4ec2946d48ba4bf3a08bb6bfdce28a4dd52d57f0860e17a1754e847c8c88b3"
+    sha256               x86_64_linux:  "aa7c257dc2a7e517572e6b588c3c205a05171aab45b17047571ebf76c85a5080"
   end
 
   head do


### PR DESCRIPTION
- **[no ci] update freecad alias to point to v1.1.3 release**
- **[no ci] freecad@1.1.3_py313_qt6: fix style error with newly added bottle block in formula file**

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
