### PR TITLE
boost python3@1.90 py313

### DIFF
--- a/Formula/boost-python3@1.92_py313.rb
+++ b/Formula/boost-python3@1.92_py313.rb
@@ -1,0 +1,98 @@
+class BoostPython3AT192Py313 < Formula
+  desc "C++ library for C++/Python3 interoperability"
+  homepage "https://www.boost.org/"
+  url "https://github.com/boostorg/boost/releases/download/boost-1.92.0/boost-1.92.0-b2-nodocs.tar.xz"
+  sha256 "ea7b982002cc9dfbe59b0b217b206f470dc75f3de0bb2973d844118934d82411"
+  license "BSL-1.0"
+  compatibility_version 2
+  head "https://github.com/boostorg/boost.git", branch: "master"
+  livecheck do
+    formula "boost"
+  end
+  keg_only :versioned_formula
+  depends_on "numpy" => :build
+  depends_on "boost"
+  depends_on "python@3.13"
+  def python3
+    "python3.13"
+  end
+
+  def install
+    boost_version = Formula["boost"].version
+    odie "boost is #{boost_version}, formula builds #{version}" if boost_version != version
+    # "layout" should be synchronized with boost
+    args = %W[
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=system
+      --user-config=user-config.jam
+      install
+      threading=multi
+      link=shared,static
+    ]
+    # Boost is using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++" if ENV.compiler == :clang
+    # Avoid linkage to boost container and graph modules
+    # Issue ref: https://github.com/boostorg/boost/issues/985
+    args << "linkflags=-Wl,-dead_strip_dylibs" if OS.mac?
+    # disable python detection in bootstrap.sh; it guesses the wrong include
+    # directory for Python 3 headers, so we configure python manually in
+    # user-config.jam below.
+    inreplace "bootstrap.sh", "using python", "#using python"
+    pyver = Language::Python.major_minor_version python3
+    py_prefix = if OS.mac?
+      Formula["python@#{pyver}"].opt_frameworks/"Python.framework/Versions"/pyver
+    else
+      formula_opt_prefix("python@#{pyver}")
+    end
+    # Force boost to compile with the desired compiler
+    (buildpath/"user-config.jam").write <<~EOS
+      using #{OS.mac? ? "darwin" : "gcc"} : : #{ENV.cxx} ;
+      using python : #{pyver}
+                   : #{python3}
+                   : #{py_prefix}/include/python#{pyver}
+                   : #{py_prefix}/lib ;
+    EOS
+    system "./bootstrap.sh", "--prefix=#{prefix}",
+      "--libdir=#{lib}",
+      "--with-libraries=python",
+      "--with-python=#{python3}",
+      "--with-python-root=#{py_prefix}"
+    system "./b2", "--build-dir=build-python3",
+      "--stagedir=stage-python3",
+      "--libdir=install-python3/lib",
+      "--prefix=install-python3",
+      "python=#{pyver}",
+      *args
+    lib.install buildpath.glob("install-python3/lib/*{python,numpy}*")
+    (lib/"cmake").install buildpath.glob("install-python3/lib/cmake/*{python,numpy}*")
+    # Fix the path to headers installed in `boost` formula
+    cmake_configs = lib.glob("cmake/boost_{python,numpy}*/boost_{python,numpy}-config.cmake")
+    inreplace cmake_configs, '(_BOOST_INCLUDEDIR "${_BOOST_CMAKEDIR}/../../include/" ABSOLUTE)',
+      "(_BOOST_INCLUDEDIR \"#{formula_opt_include("boost")}/\" ABSOLUTE)"
+  end
+  test do
+    (testpath/"hello.cpp").write <<~CPP
+      #include <boost/python.hpp>
+      char const* greet() {
+        return "Hello, world!";
+      }
+      BOOST_PYTHON_MODULE(hello)
+      {
+        boost::python::def("greet", greet);
+      }
+    CPP
+    pyincludes = shell_output("#{python3}-config --includes").chomp.split
+    pylib = shell_output("#{python3}-config --ldflags --embed").chomp.split
+    pyver = Language::Python.major_minor_version(python3).to_s.delete(".")
+    system ENV.cxx, "-shared", "-fPIC", "-std=c++14", "hello.cpp", "-L#{lib}", "-lboost_python#{pyver}",
+      "-o", "hello.so", *pyincludes, *pylib
+    output = <<~PYTHON
+      import hello
+      print(hello.greet())
+    PYTHON
+    assert_match "Hello, world!", pipe_output(python3, output, 0)
+  end
+end


### PR DESCRIPTION
- **copy upstream boost-python3 formula into a tap versioned formula file**
- **boost-python3@1.90_py313: update formula to use python v3.13**
- **boost-python3@1.90_py313: update formula to use new class name, and make formula keg only**

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
