### PR TITLE
[no ci] fix all style errors through homebrew-freecad repo

### DIFF
--- a/Formula/ondselsolver.rb
+++ b/Formula/ondselsolver.rb
@@ -27,7 +27,7 @@ class Ondselsolver < Formula
     cd buildpath do
       build_dir = File.join(Dir.pwd, "build")
       mkdir build_dir do
-        system "cmake", "..", "-L", *std_cmake_args
+        system "cmake", "-S", "..", "-B", ".", "-L", *std_cmake_args
         system "cmake", "--build", build_dir.to_s
         system "cmake", "--install", build_dir.to_s
       end

--- a/Formula/opencascade@7.5.0.rb
+++ b/Formula/opencascade@7.5.0.rb
@@ -23,7 +23,7 @@ class OpencascadeAT750 < Formula
   depends_on "tbb"
 
   def install
-    system "cmake", ".",
+    system "cmake", "-S", ".", "-B", ".",
                     "-DUSE_FREEIMAGE=ON",
                     "-DUSE_RAPIDJSON=ON",
                     "-DUSE_TBB=ON",

--- a/Formula/opencascade@7.5.3.rb
+++ b/Formula/opencascade@7.5.3.rb
@@ -41,7 +41,7 @@ class OpencascadeAT753 < Formula
 
   def install
     tcltk = Formula["tcl-tk"]
-    system "cmake", ".",
+    system "cmake", "-S", ".", "-B", ".",
                     "-DUSE_FREEIMAGE=ON",
                     "-DUSE_RAPIDJSON=ON",
                     "-DUSE_TBB=ON",

--- a/Formula/opencascade@7.6.0.rb
+++ b/Formula/opencascade@7.6.0.rb
@@ -37,7 +37,7 @@ class OpencascadeAT760 < Formula
 
   def install
     tcltk = Formula["tcl-tk"]
-    system "cmake", ".",
+    system "cmake", "-S", ".", "-B", ".",
                     "-DUSE_FREEIMAGE=ON",
                     "-DUSE_RAPIDJSON=ON",
                     "-DUSE_TBB=ON",

--- a/Formula/vtk@9.5.2_py312.rb
+++ b/Formula/vtk@9.5.2_py312.rb
@@ -165,7 +165,8 @@ class VtkAT952Py312 < Formula
       }
     CPP
 
-    system "cmake", ".", "-DCMAKE_BUILD_TYPE=Debug", "-DCMAKE_VERBOSE_MAKEFILE=ON", "-DVTK_DIR=#{vtk_dir}"
+    system "cmake", "-S", ".", "-B", ".", "-DCMAKE_BUILD_TYPE=Debug", "-DCMAKE_VERBOSE_MAKEFILE=ON",
+"-DVTK_DIR=#{vtk_dir}"
     system "make"
     system "./Distance2BetweenPoints"
 

--- a/Formula/vtk@9.5.2_py313.rb
+++ b/Formula/vtk@9.5.2_py313.rb
@@ -162,7 +162,8 @@ class VtkAT952Py313 < Formula
       }
     CPP
 
-    system "cmake", ".", "-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DCMAKE_VERBOSE_MAKEFILE=ON", "-DVTK_DIR=#{vtk_dir}"
+    system "cmake", "-S", ".", "-B", ".", "-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DCMAKE_VERBOSE_MAKEFILE=ON",
+"-DVTK_DIR=#{vtk_dir}"
     system "make"
     system "./Distance2BetweenPoints"
 


### PR DESCRIPTION
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
