### PR TITLE
fc bundle py313 qt6

### DIFF
--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -32,6 +32,7 @@ class FcBundlePy313Qt6 < Formula
   depends_on "freecad/freecad/vtk@9.5.2_py313"
   depends_on "geos"
   depends_on "libyaml"
+  depends_on "llvm" if OS.linux?
   depends_on "numpy"
   depends_on "pybind11" # req'd by pyyaml
   depends_on "webp" if OS.linux?
@@ -192,6 +193,18 @@ class FcBundlePy313Qt6 < Formula
 
         new_rpath = [zlib_lib, existing_rpath].reject(&:empty?).join(":")
         system "patchelf", "--set-rpath", new_rpath, so
+      end
+
+      # fix rpath related issues with opencamlib
+      omp_dir = Dir[formula_opt_lib("llvm")/"*/libomp.so"].first
+      odie "libomp.so not found under llvm" if omp_dir.nil?
+      omp_dir = File.dirname(omp_dir)
+
+      ocl_so = Dir[venv_dir/"lib/python#{pyver}/site-packages/opencamlib/ocl*.so"].first
+      if ocl_so
+        existing = Utils.safe_popen_read("patchelf", "--print-rpath", ocl_so).strip
+        new_rpath = [omp_dir, existing].reject(&:empty?).join(":")
+        system "patchelf", "--set-rpath", new_rpath, ocl_so
       end
     end
 

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -23,6 +23,7 @@ class FcBundlePy313Qt6 < Formula
 
   depends_on "patchelf" => :build
   depends_on "pkgconf" => :build
+  depends_on "freetype" # req'd by matplotlib
   depends_on "ffmpeg"
   depends_on "freecad/freecad/boost-python3@1.92_py313"
   depends_on "freecad/freecad/coin3d@4.0.8_py313_qt6"
@@ -31,10 +32,12 @@ class FcBundlePy313Qt6 < Formula
   depends_on "freecad/freecad/pyside6_py313" # pyside includes the shiboken module as well
   depends_on "freecad/freecad/vtk@9.5.2_py313"
   depends_on "geos"
+  depends_on "libomp" if OS.linux?
   depends_on "libyaml"
   depends_on "llvm" if OS.linux?
   depends_on "numpy"
   depends_on "pybind11" # req'd by pyyaml
+  depends_on "qhull" # req'd by matplotlib
   depends_on "webp" if OS.linux?
   depends_on "zlib-ng-compat" if OS.linux?
 
@@ -139,10 +142,18 @@ class FcBundlePy313Qt6 < Formula
     # Install the six module using pip in the virtual environment
     # certain freecad workbenches require the python six module
     # setup and install lark ply six
-    %w[av defusedxml matplotlib lark ply pyyaml six typing-extensions].each do |pkg|
+    %w[av defusedxml lark ply pyyaml six typing-extensions].each do |pkg|
       resource(pkg).stage do
         system venv_pip, "install", "."
       end
+    end
+
+    resource("matplotlib").stage do
+      # NOTE: added the below because matplotlib vendors harfbuzz can not use brew provided
+      ENV["CXXFLAGS"] = "#{ENV["CXXFLAGS"]} -DHB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR"
+      system venv_pip, "install", ".",
+        "--config-settings=setup-args=-Dsystem-freetype=true",
+        "--config-settings=setup-args=-Dsystem-qhull=true",
     end
 
     # opencamlib's pyproject.toml still uses the pre-0.10 scikit-build-core key

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -33,7 +33,7 @@ class FcBundlePy313Qt6 < Formula
   depends_on "freecad/freecad/vtk@9.5.2_py313"
   depends_on "freetype" # req'd by matplotlib
   depends_on "geos"
-  depends_on "libomp" if OS.linux?
+  depends_on "libomp"
   depends_on "libyaml"
   depends_on "llvm" if OS.linux?
   depends_on "numpy"

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -23,7 +23,6 @@ class FcBundlePy313Qt6 < Formula
 
   depends_on "patchelf" => :build
   depends_on "pkgconf" => :build
-  depends_on "freetype" # req'd by matplotlib
   depends_on "ffmpeg"
   depends_on "freecad/freecad/boost-python3@1.92_py313"
   depends_on "freecad/freecad/coin3d@4.0.8_py313_qt6"
@@ -31,6 +30,7 @@ class FcBundlePy313Qt6 < Formula
   depends_on "freecad/freecad/netgen@6.2.2601"
   depends_on "freecad/freecad/pyside6_py313" # pyside includes the shiboken module as well
   depends_on "freecad/freecad/vtk@9.5.2_py313"
+  depends_on "freetype" # req'd by matplotlib
   depends_on "geos"
   depends_on "libomp" if OS.linux?
   depends_on "libyaml"
@@ -207,9 +207,12 @@ class FcBundlePy313Qt6 < Formula
       end
 
       # fix rpath related issues with opencamlib
-      omp_dir = Dir[formula_opt_lib("llvm")/"*/libomp.so"].first
-      odie "libomp.so not found under llvm" if omp_dir.nil?
-      omp_dir = File.dirname(omp_dir)
+      omp_lib = Dir[
+        formula_opt_lib("llvm")/"libomp.so",
+        formula_opt_lib("llvm")/"*/libomp.so",
+      ].first
+      odie "libomp.so not found under llvm" if omp_lib.nil?
+      omp_dir = File.dirname(omp_lib)
 
       ocl_so = Dir[venv_dir/"lib/python#{pyver}/site-packages/opencamlib/ocl*.so"].first
       if ocl_so

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -82,7 +82,7 @@ class FcBundlePy313Qt6 < Formula
   # Last tagged release (2023.01.11) predates scikit-build-core 1.0
   resource "opencamlib" do
     url "https://github.com/aewallin/opencamlib.git",
-      revisison: "95b036fe28ce6d77c97b98e5fbc337904ae49560"
+      revision: "95b036fe28ce6d77c97b98e5fbc337904ae49560"
   end
 
   resource "ply" do

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -23,6 +23,7 @@ class FcBundlePy313Qt6 < Formula
 
   depends_on "patchelf" => :build
   depends_on "pkgconf" => :build
+  depends_on "boost"
   depends_on "ffmpeg"
   depends_on "freecad/freecad/boost-python3@1.92_py313"
   depends_on "freecad/freecad/coin3d@4.0.8_py313_qt6"

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -149,10 +149,13 @@ class FcBundlePy313Qt6 < Formula
     # build backend to the last series that accepts them.
     resource("opencamlib").stage do
       inreplace "pyproject.toml", /["']scikit-build-core[^"']*["']/, '"scikit-build-core<1.0"'
-      args = []
+      # args = []
       if OS.linux?
-        args << "--config-settings=cmake.define.CMAKE_AR=#{formula_opt_bin("llvm")}/llvm-ar"
-        args << "--config-settings=cmake.define.CMAKE_RANLIB=#{formula_opt_bin("llvm")}/llvm-ranlib"
+        ENV["AR"] = "#{formula_opt_bin("llvm")}/llvm-ar"
+        ENV["RANLIB"] = "#{formula_opt_bin("llvm")}/llvm-ranlib"
+        # NOTE: another possible fix, use `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF`
+        # args << "--config-settings=cmake.define.CMAKE_AR=#{formula_opt_bin("llvm")}/llvm-ar"
+        # args << "--config-settings=cmake.define.CMAKE_RANLIB=#{formula_opt_bin("llvm")}/llvm-ranlib"
       end
       system venv_pip, "install", "."
     end

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -24,6 +24,7 @@ class FcBundlePy313Qt6 < Formula
   depends_on "patchelf" => :build
   depends_on "pkgconf" => :build
   depends_on "ffmpeg"
+  depends_on "freecad/freecad/boost-python3@1.92_py313"
   depends_on "freecad/freecad/coin3d@4.0.8_py313_qt6"
   depends_on "freecad/freecad/med-file@5.0.0_py313"
   depends_on "freecad/freecad/netgen@6.2.2601"

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -149,6 +149,11 @@ class FcBundlePy313Qt6 < Formula
     # build backend to the last series that accepts them.
     resource("opencamlib").stage do
       inreplace "pyproject.toml", /["']scikit-build-core[^"']*["']/, '"scikit-build-core<1.0"'
+      args = []
+      if OS.linux?
+        args << "--config-settings=cmake.define.CMAKE_AR=#{formula_opt_bin("llvm")}/llvm-ar"
+        args << "--config-settings=cmake.define.CMAKE_RANLIB=#{formula_opt_bin("llvm")}/llvm-ranlib"
+      end
       system venv_pip, "install", "."
     end
 

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -10,7 +10,7 @@ class FcBundlePy313Qt6 < Formula
   version "1.1.1"
   # sha of file:///dev/null
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  revision 8
+  revision 9
 
   bottle do
     root_url "https://ghcr.io/v2/freecad/freecad"
@@ -77,6 +77,13 @@ class FcBundlePy313Qt6 < Formula
     sha256 "b8a1eae79e86021624b43484bd07cb318ee83aa5f4ed4c3044dcfdcea63b07fe"
   end
 
+  # NOTE: added due to issue, https://github.com/freecad/homebrew-freecad/issues/854
+  # Last tagged release (2023.01.11) predates scikit-build-core 1.0
+  resource "opencamlib" do
+    url "https://github.com/aewallin/opencamlib.git",
+      revisison: "95b036fe28ce6d77c97b98e5fbc337904ae49560"
+  end
+
   resource "ply" do
     url "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz"
     sha256 "00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
@@ -134,6 +141,14 @@ class FcBundlePy313Qt6 < Formula
       resource(pkg).stage do
         system venv_pip, "install", "."
       end
+    end
+
+    # opencamlib's pyproject.toml still uses the pre-0.10 scikit-build-core key
+    # names (cmake.verbose et al), which 1.0 turned into hard errors. Pin the
+    # build backend to the last series that accepts them.
+    resource("opencamlib").stage do
+      inreplace "pyproject.toml", /["']scikit-build-core[^"']*["']/, '"scikit-build-core<1.0"'
+      system venv_pip, "install", "."
     end
 
     resource("pynastran").stage do

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -153,7 +153,7 @@ class FcBundlePy313Qt6 < Formula
       ENV["CXXFLAGS"] = "#{ENV["CXXFLAGS"]} -DHB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR"
       system venv_pip, "install", ".",
         "--config-settings=setup-args=-Dsystem-freetype=true",
-        "--config-settings=setup-args=-Dsystem-qhull=true",
+        "--config-settings=setup-args=-Dsystem-qhull=true"
     end
 
     # opencamlib's pyproject.toml still uses the pre-0.10 scikit-build-core key

--- a/Formula/fc_bundle_py313_qt6.rb
+++ b/Formula/fc_bundle_py313_qt6.rb
@@ -149,13 +149,9 @@ class FcBundlePy313Qt6 < Formula
     # build backend to the last series that accepts them.
     resource("opencamlib").stage do
       inreplace "pyproject.toml", /["']scikit-build-core[^"']*["']/, '"scikit-build-core<1.0"'
-      # args = []
       if OS.linux?
-        ENV["AR"] = "#{formula_opt_bin("llvm")}/llvm-ar"
-        ENV["RANLIB"] = "#{formula_opt_bin("llvm")}/llvm-ranlib"
         # NOTE: another possible fix, use `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF`
-        # args << "--config-settings=cmake.define.CMAKE_AR=#{formula_opt_bin("llvm")}/llvm-ar"
-        # args << "--config-settings=cmake.define.CMAKE_RANLIB=#{formula_opt_bin("llvm")}/llvm-ranlib"
+        ENV.prepend_path "PATH", formula_opt_bin("llvm")
       end
       system venv_pip, "install", "."
     end
@@ -233,7 +229,7 @@ class FcBundlePy313Qt6 < Formula
   def caveats
     <<-EOS
     this formula is required to get necessary python runtime deps
-    working with freecad ie. freecad@1.0.2_py313_qt6
+    working with freecad ie. freecad@1.1.3_py313_qt6
     EOS
   end
 


### PR DESCRIPTION
- **fc_bundle_py313_qt6: scaffold out support for opencamlib py module**
- **fc_bundle_py313_qt6: add boost-python3@1.92_py313 as a dep for opencamlib**
- **fc_bundle_py313_qt6: update list of configure args for cmake when compiling opencamlib**
- **fc_bundle_py313_qt6: update list of configure args for cmake when compiling opencamlib**
- **fc_bundle_py313_qt6: fix typo for opencamlib resource block**
- **fc_bundle_py313_qt6: update opencamlib args for building, update caveats wording**
- **fc_bundle_py313_qt6: add llvm as a runtime dep for libomp.so and attempt to resolve rpath related issues for opencamlib**
- **fc_bundle_py313_qt6: matplotlib bld err's should be resolved, broke matplotlib into it's own resource block**
- **fc_bundle_py313_qt6: fix syntax err**
- **fc_bundle_py313_qt6: update meata freecad package to include opencamlib**

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?

<!-- NOTE: ipatch, recently rubocop started styling this file, the below code example causes a styling error  -->
```shell
brew style freecad/freecad/[NAME_OF_FORMULA_FILE]
```

**output** from running above command should _output_ something similiar to the below

```
1 file inspected, no offenses detected
```

- [ ] Have you ensured your commit passed audit checks, ie.

```shell
brew audit freecad/freecad/[NAME_OF_FORMULA_FILE] --online --new-formula
```

---

Not all PRs require passing these checks ie. adding `[no ci]` in the commit message will prevent the CI from running but PRs that change formula files generally should run through the CI checks that way new bottles are built and uploaded to the repository thus not having to build all formula from source but rather installing from a bottle (significantly faster 🐰 ... 🐢)

For more information about this template file [learn more][lm1]


[lm1]: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>
